### PR TITLE
Reimagine SDK around Eve-style filesystem-first agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,11 @@ go test ./pkg/agents
   - Catalog is appended to the system prompt; bodies are pulled via the `load_skill` builtin tool
   - Remote skills (`RemoteSource`): declared in `agent.yaml`, fetched at load time, pinned by commit SHA, `sha256`-verified, host-allowlisted, and cached (never model-driven runtime fetches)
 
+- **`pkg/mcp/`** - Model Context Protocol integration
+  - Connects to MCP servers over stdio or streamable-HTTP using `modelcontextprotocol/go-sdk`
+  - Adapts each server tool into the SDK's `tools.Tool` interface (namespaced as `<server>_<tool>`)
+  - `Manager` aggregates multiple servers; connections close via `Agent.Close()`
+
 - **`pkg/channels/`** - Integration adapters
   - `Channel` interface; built-in `HTTPChannel` powers `eve dev` (POST /chat)
 
@@ -103,11 +108,12 @@ wired by calling `loader.Load(dir, registry)` from your own program.
 - `github.com/mattn/go-sqlite3` - SQLite database driver
 - `golang.org/x/sync/errgroup` - Concurrent execution patterns
 - `gopkg.in/yaml.v3` - YAML parsing for `agent.yaml`, skills front-matter, schedules
+- `github.com/modelcontextprotocol/go-sdk` - MCP client (stdio + streamable-HTTP)
 - Provider SDKs: `anthropic-sdk-go`, `openai-go`, `ollama`, `google.golang.org/genai`
 
 ## Development Notes
 
 - Provider, guardrail, and tracing packages are implemented
 - Tests live alongside code as `*_test.go` (loader, skills, schedules, tools, agents)
-- Module uses Go 1.24.3
+- Module requires Go 1.25 (raised by the MCP SDK dependency)
 - Build the CLI with `make build-cli`; validate the example with `make run-fs-example`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,24 @@ go test ./pkg/agents
 
 - **`pkg/tools/`** - Tool system for agent capabilities
   - `FunctionTool` - Wraps Go functions as tools using reflection
-  - Automatic schema generation from function signatures
+  - `SimpleTool` (`NewTool`) - Tools with explicit, named parameter schemas
+  - `Registry` - Name-indexed tool collection used by the filesystem loader
   - Support for context-aware tool execution
+
+- **`pkg/loader/`** - Filesystem-first agent loading
+  - Builds an `Agent` from a directory (`agent.yaml`, `instructions.md`, `skills/`, `subagents/`)
+  - Resolves tools declared by name in `agent.yaml` against a `tools.Registry`
+  - Loads subagents recursively as handoffs
+
+- **`pkg/skills/`** - On-demand knowledge (Eve-style skills)
+  - Markdown files with YAML front-matter (`name`, `description`)
+  - Catalog is appended to the system prompt; bodies are pulled via the `load_skill` builtin tool
+
+- **`pkg/channels/`** - Integration adapters
+  - `Channel` interface; built-in `HTTPChannel` powers `eve dev` (POST /chat)
+
+- **`pkg/schedules/`** - Cron-based autonomous triggers
+  - Dependency-free 5-field cron parser/matcher and a minute-tick scheduler
 
 - **`pkg/memory/`** - Session management and persistence
   - SQLite-based session storage for conversation history
@@ -56,23 +72,40 @@ go test ./pkg/agents
   - Distributed tracing support for agent runs
   - Span tracking for debugging and performance analysis
 
+### The `cmd/eve` CLI
+
+The `eve` binary is a thin shell over the library:
+
+- `eve init <dir>` - scaffold a new agent directory
+- `eve validate <dir>` - load an agent and report what was found (no API key needed)
+- `eve run <dir> [input]` - run a single turn
+- `eve dev <dir> [addr]` - serve the agent over HTTP via the HTTP channel
+- `eve schedules <dir>` - run the agent's cron schedules
+
+Because Go tools are compiled, the CLI resolves `agent.yaml` tool names against a
+small builtin registry (`current_time`, `add`, `http_get`). Custom Go tools are
+wired by calling `loader.Load(dir, registry)` from your own program.
+
 ### Key Patterns
 
-- **Agent Handoffs**: Agents can delegate to other agents with context
-- **Tool Execution**: Supports both parallel and sequential tool execution
-- **Turn Management**: Configurable max turns with timeout protection
-- **Structured Output**: Type-safe output schemas with validation
-- **Error Handling**: Comprehensive error propagation and context
+- **Filesystem-first**: agents are directories; the loader translates files into `agents.NewAgent` option calls
+- **Skills on demand**: catalog in the prompt + `load_skill` builtin tool, rather than inlining all knowledge
+- **Agent Handoffs**: subagent directories become handoff targets
+- **Tool Execution**: supports both parallel and sequential tool execution
+- **Turn Management**: configurable max turns with timeout protection
+- **Error Handling**: comprehensive error propagation and context
 
 ### Dependencies
 
 - `github.com/google/uuid` - UUID generation
 - `github.com/mattn/go-sqlite3` - SQLite database driver
 - `golang.org/x/sync/errgroup` - Concurrent execution patterns
+- `gopkg.in/yaml.v3` - YAML parsing for `agent.yaml`, skills front-matter, schedules
+- Provider SDKs: `anthropic-sdk-go`, `openai-go`, `ollama`, `google.golang.org/genai`
 
 ## Development Notes
 
-- Missing packages (`providers`, `guardrails`, `tracing`) need implementation
-- No test files currently exist - tests should be added as `*_test.go`
+- Provider, guardrail, and tracing packages are implemented
+- Tests live alongside code as `*_test.go` (loader, skills, schedules, tools, agents)
 - Module uses Go 1.24.3
-- README.md and Makefile are empty and should be populated
+- Build the CLI with `make build-cli`; validate the example with `make run-fs-example`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,11 @@ go test ./pkg/agents
   - Input validation before agent processing
   - Pluggable guardrail architecture
 
-- **`pkg/tracing/`** - Observability and monitoring
-  - Distributed tracing support for agent runs
-  - Span tracking for debugging and performance analysis
+- **`pkg/tracing/`** - Observability: tracing + structured logging
+  - `Tracer`/`Span` with context-propagated depth so spans form a tree; use `tracing.Start`
+  - Tracers: `NewConsoleTracer`, `NewSlogTracer`, `NewRecorder` (programmatic), `NewTee` (combine)
+  - `slog` helpers (`NewLogger`, `DiscardLogger`, `ParseLevel`); runner takes `WithLogger`
+  - The runner spans agent.run → turn → llm.complete / tool.execute / guardrails / handoff.delegate, and fills `RunResult.Traces`
 
 ### The `cmd/eve` CLI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,6 @@ wired by calling `loader.Load(dir, registry)` from your own program.
 
 - `github.com/google/uuid` - UUID generation
 - `github.com/mattn/go-sqlite3` - SQLite database driver
-- `golang.org/x/sync/errgroup` - Concurrent execution patterns
 - `gopkg.in/yaml.v3` - YAML parsing for `agent.yaml`, skills front-matter, schedules
 - `github.com/modelcontextprotocol/go-sdk` - MCP client (stdio + streamable-HTTP)
 - Provider SDKs: `anthropic-sdk-go`, `openai-go`, `ollama`, `google.golang.org/genai`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ go test ./pkg/agents
 - **`pkg/skills/`** - On-demand knowledge (Eve-style skills)
   - Markdown files with YAML front-matter (`name`, `description`)
   - Catalog is appended to the system prompt; bodies are pulled via the `load_skill` builtin tool
+  - Remote skills (`RemoteSource`): declared in `agent.yaml`, fetched at load time, pinned by commit SHA, `sha256`-verified, host-allowlisted, and cached (never model-driven runtime fetches)
 
 - **`pkg/channels/`** - Integration adapters
   - `Channel` interface; built-in `HTTPChannel` powers `eve dev` (POST /chat)
@@ -90,7 +91,8 @@ wired by calling `loader.Load(dir, registry)` from your own program.
 
 - **Filesystem-first**: agents are directories; the loader translates files into `agents.NewAgent` option calls
 - **Skills on demand**: catalog in the prompt + `load_skill` builtin tool, rather than inlining all knowledge
-- **Agent Handoffs**: subagent directories become handoff targets
+- **Agent Handoffs**: subagent directories become handoff targets, exposed to the model as `handoff_<name>` tools and intercepted by the Runner
+- **Handoff context modes**: `shared` (transfer control, default), `fresh` (delegate with task only, returns), `forked` (delegate with a copy of history, returns); set per subagent in `agent.yaml` or via `agents.WithHandoff`
 - **Tool Execution**: supports both parallel and sequential tool execution
 - **Turn Management**: configurable max turns with timeout protection
 - **Error Handling**: comprehensive error propagation and context

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifneq (,$(wildcard ./.env))
     export
 endif
 
-.PHONY: help build test run-example clean fmt vet tidy env
+.PHONY: help build build-cli test run-example clean fmt vet tidy env run-fs-example
 
 # Default target
 help: ## Show this help message
@@ -19,6 +19,14 @@ env: ## Export environment variables from .env file
 build: ## Build all packages
 	@echo "Building all packages..."
 	go build ./...
+
+build-cli: ## Build the eve CLI into bin/eve
+	@echo "Building eve CLI..."
+	go build -o bin/eve ./cmd/eve
+
+run-fs-example: build-cli ## Validate the filesystem-first example agent
+	@echo "Validating filesystem-first example agent..."
+	./bin/eve validate examples/filesystem-agent/assistant
 
 test: ## Run tests
 	@echo "Running tests..."

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,6 +1,34 @@
 # Go Agents SDK Quickstart
 
-Build an AI agent that manages event scheduling and detects overlaps in user schedules.
+## Fastest path: the filesystem-first `eve` CLI
+
+An agent is just a directory of files. Scaffold, inspect, and run one in under a
+minute:
+
+```bash
+# From the repo root, build the CLI:
+go build -o eve ./cmd/eve
+
+# Scaffold a new agent and see what it contains:
+./eve init myagent
+./eve validate myagent
+
+# Provide a provider key, then run it:
+export OPENAI_API_KEY=...        # or ANTHROPIC_API_KEY / GEMINI_API_KEY / OLLAMA_HOST
+./eve run myagent "What time is it, and what is 2 + 2?"
+
+# Or serve it over HTTP:
+./eve dev myagent
+#   curl -s localhost:8080/chat -d '{"input":"hello"}'
+```
+
+Edit `myagent/agent.yaml` (model, provider, tools), `myagent/instructions.md`
+(system prompt), and add `myagent/skills/*.md` for on-demand knowledge. See the
+[README](README.md) and [`examples/filesystem-agent`](examples/filesystem-agent)
+for the full layout.
+
+The rest of this guide builds the same kind of agent **in code** with the
+library API, using event scheduling as a worked example.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,49 @@ Skills are not dumped into the prompt. Instead the model sees a **catalog** of
 skill names and descriptions and pulls a skill's full body only when needed,
 via the built-in `load_skill` tool.
 
+### Remote skills (pinned by commit SHA)
+
+Skills can be shared across projects — like a plugin marketplace — by declaring
+**remote sources** in `agent.yaml`. They're resolved **at load time** (never by
+the model at runtime), pinned to an immutable commit SHA, integrity-checked
+against an optional `sha256`, restricted to an allowlisted host, and cached
+locally. This gives you marketplace ergonomics without the prompt-injection/SSRF
+risk of fetching model-supplied URLs.
+
+```yaml
+# agent.yaml — local skills/ are loaded too, in addition to these
+skills:
+  - source: github.com/acme/agent-skills/refunds.md
+    ref: a1b2c3d4         # commit SHA — required for github.com sources
+    sha256: 9f86d0…       # optional integrity pin
+  - source: https://example.com/pinned/skill.md
+    sha256: 0b1c2d…
+```
+
+Defaults are safe: only `raw.githubusercontent.com` / `gist.githubusercontent.com`
+are allowed unless you widen the allowlist via `loader.LoadWithOptions`.
+
+### Subagent handoffs: three context modes
+
+Each subagent handoff can carry context in one of three ways, set per subagent
+in the parent's `agent.yaml`:
+
+```yaml
+subagents:
+  researcher: forked   # shared (default) | fresh | forked
+```
+
+| Mode       | Subagent sees           | Returns to parent? | Use case                          |
+|------------|-------------------------|--------------------|-----------------------------------|
+| **shared** | the full live history   | no (transfers control) | routing/triage                |
+| **fresh**  | only the task           | yes                | clean delegation, no context bleed |
+| **forked** | a copy of the history   | yes                | independent exploration; parent resumes unaffected |
+
+In code: `agents.WithHandoffs(sub)` (shared) or
+`agents.WithHandoff(sub, agents.ContextFresh|ContextForked)`. The model triggers
+a handoff by calling the auto-generated `handoff_<name>` tool; the runner
+intercepts it and applies the configured mode.
+
 ## The `eve` CLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -138,6 +138,42 @@ namespaced by server to avoid collisions. From code, use `mcp.ConnectAll` and
 add `manager.Tools()` to an agent, or just let the loader do it. Remember to
 `defer agent.Close()` to release MCP connections.
 
+## Observability: logging & tracing
+
+Every run is instrumented. The runner emits **structured logs** (`log/slog`) and a
+**span tree** covering the run, each turn, every LLM call, tool execution
+(including skills' `load_skill` and MCP tools), guardrails, and handoffs/
+delegations.
+
+```go
+runner := agents.NewRunner(
+    agents.WithProvider(p),
+    agents.WithLogger(tracing.NewLogger(os.Stderr, slog.LevelDebug)), // structured logs
+    agents.WithTracer(tracing.NewConsoleTracer()),                    // indented span tree
+)
+result, _ := runner.Run(ctx, agent, "hello")
+
+// The full trace tree is always captured programmatically, regardless of tracer:
+for _, span := range result.Traces {
+    fmt.Printf("%*s%s %s\n", span.Depth*2, "", span.Name, span.Duration)
+}
+```
+
+Console trace output looks like:
+
+```
+[trace] agent.run (12.4ms) agent=assistant turns=2 tokens=345
+[trace]   turn (8.1ms) n=0 agent=assistant
+[trace]     llm.complete (6.0ms) model=gpt-4o tokens=210 tool_calls=1
+[trace]     tool.execute (1.2ms) tool=add args={"a":5,"b":3} result_chars=1
+[trace]   turn (3.9ms) n=1 agent=assistant
+[trace]     llm.complete (3.8ms) model=gpt-4o tokens=135 tool_calls=0
+```
+
+Tracers available in `pkg/tracing`: `NewConsoleTracer`, `NewSlogTracer`,
+`NewRecorder` (programmatic capture), and `NewTee` to combine them. With the
+CLI, enable both with `-v`/`--verbose`, or set `EVE_LOG=debug` / `EVE_TRACE=1`.
+
 ## The `eve` CLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,419 +1,189 @@
 # Go Agents SDK
 
-A powerful Go SDK for building AI agents with tools, guardrails, memory, and multi-provider support. Create sophisticated AI systems that can make decisions, use tools, collaborate through handoffs, and maintain conversation context.
+A Go SDK for building AI agents, reimagined around a **filesystem-first**
+design inspired by [Vercel's Eve](https://vercel.com/blog/introducing-eve).
+Core agent capabilities live in conventional files and folders, so projects are
+easy to inspect, extend, and operate — while the underlying engine remains a
+plain Go library with multi-provider support, tools, skills, handoffs,
+guardrails, memory, and tracing.
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/ryanhill4L/agents-sdk.svg)](https://pkg.go.dev/github.com/ryanhill4L/agents-sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ryanhill4L/agents-sdk)](https://goreportcard.com/report/github.com/ryanhill4L/agents-sdk)
 
-## Features
+## The filesystem is the authoring interface
 
-### **Multi-Provider AI Integration**
-- **OpenAI** - GPT-4, GPT-4 Turbo, GPT-3.5 Turbo
-- **Anthropic** - Claude 3.5 Sonnet, Claude 3 Opus, Claude 3 Haiku  
-- **Google** - Gemini 2.0 Flash, Gemini 1.5 Pro
-- Unified API across all providers with automatic failover
+An agent is a directory. Conventional files describe its behaviour:
 
-### **Powerful Tool System**
-- **Function Tools** - Convert Go functions into AI-callable tools with automatic schema generation
-- **Type Safety** - Automatic parameter validation and type conversion
-- **Parallel Execution** - Tools can run concurrently for improved performance
-- **Error Handling** - Comprehensive error propagation and context
-
-### **Agent Handoffs & Orchestration**
-- **Smart Routing** - Agents can delegate tasks to specialized sub-agents
-- **Context Preservation** - Full conversation context maintained across handoffs
-- **Circular Detection** - Prevents infinite handoff loops with validation
-- **Execution Tracking** - Complete audit trail of agent interactions
-
-### **Guardrails & Safety**
-- **Input Validation** - Screen requests before processing
-- **Output Filtering** - Validate responses before returning
-- **Custom Guardrails** - Implement domain-specific safety checks
-- **Privacy Protection** - Built-in data protection patterns
-
-### **Memory & Sessions**
-- **SQLite Backend** - Persistent conversation storage
-- **Session Management** - Load and save conversation history
-- **Context Windows** - Intelligent context management for long conversations
-- **Multi-Session** - Support for concurrent user sessions
-
-### **Observability & Monitoring**
-- **Distributed Tracing** - Full request/response tracing
-- **Performance Metrics** - Token usage, latency, and success rates
-- **Debug Logging** - Detailed execution logs for troubleshooting
-- **Console Tracer** - Built-in development debugging
-
-## Quick Start
-
-### Installation
-
-```bash
-go get github.com/ryanhill4L/agents-sdk
+```
+myagent/
+  agent.yaml            # model, provider, temperature, tools
+  instructions.md       # system prompt
+  skills/
+    refunds.md          # on-demand knowledge (YAML front-matter + markdown body)
+  subagents/
+    billing/            # a delegated agent (handoff), same layout recursively
+      agent.yaml
+      instructions.md
+  schedules/
+    nightly.yaml        # cron triggers
+  channels/             # integration adapters (HTTP is built in)
 ```
 
-### Basic Example
+| Path             | Purpose                                                            |
+|------------------|-------------------------------------------------------------------|
+| `agent.yaml`     | Model, provider, sampling params, and the tools the agent may use |
+| `instructions.md`| The system prompt                                                  |
+| `skills/*.md`    | Procedures/knowledge surfaced to the model and loaded on demand   |
+| `subagents/<n>/` | Specialized agents the parent can hand off to                     |
+| `schedules/*.yaml` | Cron expressions that trigger the agent autonomously            |
+
+### `agent.yaml`
+
+```yaml
+name: assistant
+provider: openai          # openai | anthropic | gemini | ollama
+model: gpt-4o
+temperature: 0.7
+max_tokens: 1024
+tools:
+  - current_time
+  - add
+```
+
+### A skill (`skills/weather.md`)
+
+```markdown
+---
+name: weather
+description: How to answer questions about the weather using a public API.
+---
+1. Determine the location the user is asking about.
+2. Use the `http_get` tool to fetch https://wttr.in/<location>?format=3.
+3. Summarize the result in one friendly sentence.
+```
+
+Skills are not dumped into the prompt. Instead the model sees a **catalog** of
+skill names and descriptions and pulls a skill's full body only when needed,
+via the built-in `load_skill` tool.
+
+## The `eve` CLI
+
+```bash
+go build -o eve ./cmd/eve
+
+eve init myagent                     # scaffold a new agent directory
+eve validate myagent                 # load and report what was found (no API key needed)
+eve run myagent "what time is it?"   # run a single turn
+eve dev myagent                      # serve over HTTP: POST /chat {"input": "..."}
+eve schedules myagent                # run the agent's cron schedules
+```
+
+Provider credentials come from the environment:
+
+```bash
+export PROVIDER=openai            # optional; otherwise auto-detected
+export OPENAI_API_KEY=...         # or ANTHROPIC_API_KEY / GEMINI_API_KEY / OLLAMA_HOST
+```
+
+> Because Go tools are compiled functions, `agent.yaml` references tools **by
+> name**. The CLI ships a small builtin registry (`current_time`, `add`,
+> `http_get`). To use your own Go tools, load the agent from your own program
+> with a custom registry (see below).
+
+## Library API
+
+The CLI is a thin shell over the library. Load a filesystem agent with your own
+tools and run it:
 
 ```go
 package main
 
 import (
-    "context"
-    "fmt"
-    "log"
+	"context"
+	"fmt"
 
-    "github.com/ryanhill4L/agents-sdk/pkg/agents"
-    "github.com/ryanhill4L/agents-sdk/pkg/providers"
-    "github.com/ryanhill4L/agents-sdk/pkg/tools"
-    "github.com/ryanhill4L/agents-sdk/pkg/tracing"
+	"github.com/ryanhill4L/agents-sdk/pkg/agents"
+	"github.com/ryanhill4L/agents-sdk/pkg/loader"
+	"github.com/ryanhill4L/agents-sdk/pkg/providers"
+	"github.com/ryanhill4L/agents-sdk/pkg/tools"
 )
 
-// Define a simple tool
-func add(a, b int) int {
-    return a + b
-}
-
 func main() {
-    // Create a tool from your function
-    addTool, err := tools.NewFunctionTool("add", "Adds two numbers", add)
-    if err != nil {
-        log.Fatal(err)
-    }
+	// 1. Register your Go tools by name.
+	reg := tools.NewRegistry()
+	reg.MustRegister(tools.NewTool("add", "Adds two numbers",
+		func(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+			return args["a"].(float64) + args["b"].(float64), nil
+		},
+		tools.Param{Name: "a", Type: "number", Required: true},
+		tools.Param{Name: "b", Type: "number", Required: true},
+	))
 
-    // Create an agent
-    agent := agents.NewAgent("Math Assistant",
-        agents.WithInstructions("You are a helpful math assistant."),
-        agents.WithModel("gpt-4"),
-        agents.WithTools(addTool),
-    )
+	// 2. Load the agent from the filesystem.
+	agent, err := loader.Load("myagent", reg)
+	if err != nil {
+		panic(err)
+	}
 
-    // Create a provider (OpenAI, Anthropic, or Gemini)
-    provider, err := providers.NewOpenAIProviderFromEnv()
-    if err != nil {
-        log.Fatal(err)
-    }
+	// 3. Run it with a provider resolved from the environment.
+	provider, _ := providers.Resolve(agent.Provider)
+	runner := agents.NewRunner(agents.WithProvider(provider))
 
-    // Create a runner
-    runner := agents.NewRunner(
-        agents.WithProvider(provider),
-        agents.WithTracer(tracing.NewConsoleTracer()),
-    )
-
-    // Run the agent
-    ctx := context.Background()
-    result, err := runner.Run(ctx, agent, "What is 15 + 27?")
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    fmt.Printf("Response: %s\n", result.FinalOutput)
-    fmt.Printf("Tokens: %d, Duration: %v\n", 
-        result.Metrics.TotalTokens, result.Metrics.Duration)
+	result, err := runner.Run(context.Background(), agent, "What is 21 + 21?")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(result.FinalOutput)
 }
 ```
+
+You can also build agents entirely in code with functional options
+(`agents.NewAgent`, `agents.WithInstructions`, `agents.WithTools`,
+`agents.WithSkills`, `agents.WithHandoffs`, …) — the loader simply translates
+files into those calls.
+
+## Packages
+
+| Package           | Responsibility                                                        |
+|-------------------|-----------------------------------------------------------------------|
+| `pkg/agents`      | `Agent`, `Runner`, the turn loop, handoffs, skills wiring             |
+| `pkg/loader`      | Builds an `Agent` from a directory (`agent.yaml`, `instructions.md`, …) |
+| `pkg/skills`      | Skill parsing, the catalog, and the `load_skill` builtin tool         |
+| `pkg/tools`       | `Tool` interface, `Registry`, `FunctionTool` (reflection), `SimpleTool` |
+| `pkg/channels`    | Integration adapters; built-in HTTP channel (powers `eve dev`)        |
+| `pkg/schedules`   | Cron parsing and a dependency-free scheduler                          |
+| `pkg/providers`   | OpenAI, Anthropic, Gemini, and Ollama integrations + `Resolve`        |
+| `pkg/memory`      | SQLite-backed session persistence                                     |
+| `pkg/guardrails`  | Pluggable input validation                                            |
+| `pkg/tracing`     | Span-based observability (no-op and console tracers)                  |
+
+## Providers
+
+| Provider  | Env var             | Notes                           |
+|-----------|---------------------|---------------------------------|
+| OpenAI    | `OPENAI_API_KEY`    | GPT-4o and friends              |
+| Anthropic | `ANTHROPIC_API_KEY` | Claude models                   |
+| Gemini    | `GEMINI_API_KEY`    | Google Gemini                   |
+| Ollama    | `OLLAMA_HOST`       | Local models (default `:11434`) |
 
 ## Examples
 
-### Event Scheduling Agent
-A complete example showing agent handoffs, database tools, and guardrails.
+- [`examples/filesystem-agent`](examples/filesystem-agent) — the filesystem-first
+  layout, driven by the `eve` CLI (agent + skill + subagent + schedule).
+- [`examples/basic`](examples/basic), [`examples/multi-agent`](examples/multi-agent),
+  [`examples/json`](examples/json), [`examples/event-scheduler`](examples/event-scheduler)
+  — code-first usage of the library API.
+
+## Development
 
 ```bash
-cd examples/event-scheduler
-export OPENAI_API_KEY="your-key-here"
-go run main.go
-```
-
-**Features:**
-- Multi-agent orchestration with triage routing
-- Database integration with SQLite
-- Conflict detection and scheduling optimization
-- Privacy guardrails for sensitive data
-
-### Basic Tools Demo
-Simple demonstration of function tools and multi-provider support.
-
-```bash
-cd examples/basic
-export OPENAI_API_KEY="your-openai-key"
-export ANTHROPIC_API_KEY="your-anthropic-key"
-export GEMINI_API_KEY="your-gemini-key"
-go run main.go
-```
-
-### JSON Structure Example
-Shows structured output with type-safe JSON parsing.
-
-```bash
-cd examples/json
-go run main.go
-```
-
-## Architecture
-
-### Core Components
-
-```
-agents-sdk/
-├── pkg/
-│   ├── agents/          # Core agent framework
-│   │   ├── agent.go     # Agent definition and configuration
-│   │   ├── runner.go    # Execution engine with turn management
-│   │   └── types.go     # Type definitions and interfaces
-│   ├── tools/           # Tool system for agent capabilities
-│   │   ├── function_tool.go  # Go function to tool conversion
-│   │   └── tools.go     # Tool interfaces and utilities
-│   ├── providers/       # AI model provider integrations
-│   │   ├── openai_provider.go    # OpenAI GPT models
-│   │   ├── anthropic_provider.go # Anthropic Claude models
-│   │   └── gemini_provider.go    # Google Gemini models
-│   ├── memory/          # Session management and persistence
-│   │   ├── session.go   # Session interface
-│   │   └── sqlite_session.go # SQLite implementation
-│   ├── guardrails/      # Safety and validation system
-│   │   └── guardrail.go # Guardrail interfaces
-│   └── tracing/         # Observability and monitoring
-│       └── tracer.go    # Tracing interfaces and console tracer
-└── examples/            # Complete working examples
-    ├── event-scheduler/ # Multi-agent scheduling system
-    ├── basic/          # Simple tool demonstration
-    └── json/           # Structured output example
-```
-
-### Agent Lifecycle
-
-1. **Initialization** - Agent created with tools, instructions, and configuration
-2. **Validation** - Check for circular handoffs and required dependencies
-3. **Execution** - Runner manages conversation turns and tool calls
-4. **Tool Calling** - Automatic function execution with type conversion
-5. **Handoffs** - Optional delegation to specialized agents
-6. **Response** - Final output with metrics and tracing data
-
-## Configuration
-
-### Environment Variables
-
-```bash
-# AI Provider API Keys
-export OPENAI_API_KEY="sk-..."
-export ANTHROPIC_API_KEY="sk-ant-..."  
-export GEMINI_API_KEY="..."
-
-# Optional Configuration
-export AGENTS_DEBUG=true
-export AGENTS_TRACE_LEVEL=debug
-export AGENTS_MAX_TOKENS=4096
-```
-
-### Provider Configuration
-
-```go
-// OpenAI
-provider, err := providers.NewOpenAIProviderWithKey("sk-...")
-
-// Anthropic
-provider, err := providers.NewAnthropicProviderWithKey("sk-ant-...")
-
-// Gemini
-provider, err := providers.NewGeminiProviderWithKey("gemini-key")
-
-// From environment
-provider, err := providers.NewOpenAIProviderFromEnv()
-```
-
-### Agent Configuration
-
-```go
-agent := agents.NewAgent("Agent Name",
-    agents.WithInstructions("Your role and instructions"),
-    agents.WithModel("gpt-4"),
-    agents.WithTools(tool1, tool2),
-    agents.WithHandoffs(subAgent1, subAgent2),
-    agents.WithGuardrails(guardrail),
-    agents.WithTemperature(0.7),
-)
-```
-
-### Runner Configuration
-
-```go
-runner := agents.NewRunner(
-    agents.WithProvider(provider),
-    agents.WithTracer(tracing.NewConsoleTracer()),
-    agents.WithMaxTurns(10),
-    agents.WithParallelTools(true),
-)
-```
-
-## Advanced Features
-
-### Custom Tools
-
-```go
-// Database query tool
-func queryDB(query string) ([]map[string]any, error) {
-    // Your database logic
-    return results, nil
-}
-
-tool, err := tools.NewFunctionTool(
-    "query_database", 
-    "Execute SQL queries", 
-    queryDB,
-)
-```
-
-### Agent Handoffs
-
-```go
-// Specialized agents
-dataAgent := agents.NewAgent("Data Analyst", ...)
-reportAgent := agents.NewAgent("Report Generator", ...)
-
-// Orchestrator with handoffs
-orchestrator := agents.NewAgent("Coordinator",
-    agents.WithHandoffs(dataAgent, reportAgent),
-    agents.WithInstructions("Route tasks to specialists..."),
-)
-```
-
-### Memory Integration
-
-```go
-// Session-aware runner
-session, err := memory.NewSQLiteSession("./sessions.db", "user123")
-runner := agents.NewRunner(
-    agents.WithProvider(provider),
-    agents.WithSession(session),
-)
-
-// Conversation history is automatically preserved
-```
-
-### Custom Guardrails
-
-```go
-type MyGuardrail struct{}
-
-func (g *MyGuardrail) Name() string { return "my_check" }
-func (g *MyGuardrail) Description() string { return "Custom validation" }
-func (g *MyGuardrail) Validate(content string) error {
-    if containsSensitiveData(content) {
-        return fmt.Errorf("sensitive data detected")
-    }
-    return nil
-}
-
-agent := agents.NewAgent("Secure Agent",
-    agents.WithGuardrails(&MyGuardrail{}),
-)
-```
-
-## API Reference
-
-### Core Types
-
-```go
-type Agent struct {
-    // Agent configuration and state
-}
-
-type RunResult struct {
-    FinalOutput string
-    Metrics     RunMetrics
-    TraceID     string
-}
-
-type RunMetrics struct {
-    TotalTurns   int
-    ToolCalls    int
-    Handoffs     int
-    TotalTokens  int
-    Duration     time.Duration
-}
-```
-
-### Key Interfaces
-
-```go
-type Provider interface {
-    Complete(ctx context.Context, req CompletionRequest) (*CompletionResponse, error)
-}
-
-type Tool interface {
-    Name() string
-    Description() string
-    Execute(ctx context.Context, args map[string]any) (any, error)
-}
-
-type Guardrail interface {
-    Name() string
-    Description() string
-    Validate(content string) error
-}
-```
-
-## Performance & Scalability
-
-- **Concurrent Tool Execution** - Multiple tools can run in parallel
-- **Efficient Context Management** - Smart context window handling
-- **Connection Pooling** - Reused HTTP connections to providers
-- **Memory Optimization** - Efficient session storage and retrieval
-- **Timeout Handling** - Configurable timeouts for all operations
-
-## Security & Privacy
-
-- **API Key Management** - Secure credential handling
-- **Input Sanitization** - Automatic validation of user inputs
-- **Output Filtering** - Guardrails for response validation
-- **Data Isolation** - Session-based data separation
-- **Audit Logging** - Complete tracing of all operations
-
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
-
-### Development Setup
-
-```bash
-git clone https://github.com/ryanhill4L/agents-sdk.git
-cd agents-sdk
-go mod download
-go test ./...
-```
-
-### Running Tests
-
-```bash
-# Run all tests
-go test ./...
-
-# Run with coverage
-go test -cover ./...
-
-# Run specific package
-go test ./pkg/agents
+make build          # build all packages
+make build-cli      # build the eve CLI into bin/eve
+make test           # run tests
+make run-fs-example # validate the filesystem-first example
+make check          # fmt + vet + tidy
 ```
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Support
-
-- **Documentation**: [pkg.go.dev](https://pkg.go.dev/github.com/ryanhill4L/agents-sdk)
-- **Quickstart**: See [QUICKSTART.md](QUICKSTART.md)
-- **Discussions**: [GitHub Discussions](https://github.com/ryanhill4L/agents-sdk/discussions)
-- **Bug Reports**: [GitHub Issues](https://github.com/ryanhill4L/agents-sdk/issues)
-
-## Roadmap
-
-- [ ] **Stream Processing** - Real-time streaming responses
-- [ ] **Plugin System** - Dynamic tool loading
-- [ ] **Workflow Engine** - Complex multi-step processes
-- [ ] **Vector Memory** - Semantic memory with embeddings
-- [ ] **Web Interface** - Browser-based agent management
-- [ ] **Kubernetes Operator** - Cloud-native deployment
-
----
-
-Built with ❤️ by [Ryan Hill](https://github.com/ryanhill4L)
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -109,6 +109,35 @@ In code: `agents.WithHandoffs(sub)` (shared) or
 a handoff by calling the auto-generated `handoff_<name>` tool; the runner
 intercepts it and applies the configured mode.
 
+## MCP servers (Model Context Protocol)
+
+Agents gain real, dynamic tools by connecting to **MCP servers** declared in
+`agent.yaml`. Servers are connected at load time over **stdio** (local
+subprocess) or **streamable-HTTP** (remote), their tools are listed and adapted
+into the SDK's tool interface, and they're closed when the agent is. This is
+also how a CLI-run agent gets tools beyond the three builtins — without
+recompiling.
+
+```yaml
+# agent.yaml
+mcp:
+  - name: github             # tools are exposed to the model as github_<tool>
+    transport: stdio
+    command: ["npx", "-y", "@modelcontextprotocol/server-github"]
+    env: { GITHUB_TOKEN: "${GITHUB_TOKEN}" }   # $VARs are expanded
+  - name: search
+    transport: http
+    url: https://mcp.example.com
+    headers: { Authorization: "Bearer ${SEARCH_KEY}" }
+    tools: [web_search]      # optional allowlist of tool names
+```
+
+Built on the official [`modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk).
+Servers are **declared in config, never chosen by the model**; tool names are
+namespaced by server to avoid collisions. From code, use `mcp.ConnectAll` and
+add `manager.Tools()` to an agent, or just let the loader do it. Remember to
+`defer agent.Close()` to release MCP connections.
+
 ## The `eve` CLI
 
 ```bash
@@ -193,6 +222,7 @@ files into those calls.
 | `pkg/loader`      | Builds an `Agent` from a directory (`agent.yaml`, `instructions.md`, …) |
 | `pkg/skills`      | Skill parsing, the catalog, and the `load_skill` builtin tool         |
 | `pkg/tools`       | `Tool` interface, `Registry`, `FunctionTool` (reflection), `SimpleTool` |
+| `pkg/mcp`         | Connects MCP servers (stdio/HTTP) and adapts their tools to `tools.Tool` |
 | `pkg/channels`    | Integration adapters; built-in HTTP channel (powers `eve dev`)        |
 | `pkg/schedules`   | Cron parsing and a dependency-free scheduler                          |
 | `pkg/providers`   | OpenAI, Anthropic, Gemini, and Ollama integrations + `Resolve`        |

--- a/cmd/eve/builtins.go
+++ b/cmd/eve/builtins.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/ryanhill4L/agents-sdk/pkg/tools"
@@ -54,19 +56,34 @@ func addTool() tools.Tool {
 }
 
 func httpGetTool() tools.Tool {
+	// Block redirects to private/loopback/link-local hosts too, since the URL is
+	// model-controlled and could otherwise reach internal services or cloud
+	// metadata endpoints (SSRF).
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			return validatePublicURL(req.URL.String())
+		},
+	}
 	return tools.NewTool(
 		"http_get",
-		"Performs an HTTP GET request and returns the response body (truncated to 8KB).",
+		"Performs an HTTP GET request to a public URL and returns the response body (truncated to 8KB).",
 		func(ctx context.Context, args map[string]interface{}) (interface{}, error) {
-			url, _ := args["url"].(string)
-			if url == "" {
+			raw, _ := args["url"].(string)
+			if raw == "" {
 				return nil, fmt.Errorf("the 'url' argument is required")
 			}
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if err := validatePublicURL(raw); err != nil {
+				return nil, err
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, raw, nil)
 			if err != nil {
 				return nil, err
 			}
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := client.Do(req)
 			if err != nil {
 				return nil, err
 			}
@@ -77,8 +94,42 @@ func httpGetTool() tools.Tool {
 			}
 			return string(body), nil
 		},
-		tools.Param{Name: "url", Type: "string", Description: "The URL to fetch.", Required: true},
+		tools.Param{Name: "url", Type: "string", Description: "The public http(s) URL to fetch.", Required: true},
 	)
+}
+
+// validatePublicURL rejects non-http(s) schemes and URLs whose host resolves to
+// a private, loopback, link-local, or unspecified address.
+func validatePublicURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("unsupported url scheme %q (only http/https)", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("url has no host")
+	}
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return fmt.Errorf("cannot resolve host %q: %w", host, err)
+	}
+	for _, ip := range ips {
+		if isDisallowedIP(ip) {
+			return fmt.Errorf("host %q resolves to a disallowed address %s", host, ip)
+		}
+	}
+	return nil
+}
+
+func isDisallowedIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified()
 }
 
 func asFloat(v interface{}) (float64, error) {

--- a/cmd/eve/builtins.go
+++ b/cmd/eve/builtins.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/tools"
+)
+
+// builtinRegistry returns the tools the eve CLI can wire into a filesystem
+// agent by name. Projects that need custom Go tools should use the library
+// API (loader.Load with their own *tools.Registry) instead of the CLI.
+func builtinRegistry() *tools.Registry {
+	r := tools.NewRegistry()
+	r.MustRegister(
+		currentTimeTool(),
+		addTool(),
+		httpGetTool(),
+	)
+	return r
+}
+
+func currentTimeTool() tools.Tool {
+	return tools.NewTool(
+		"current_time",
+		"Returns the current date and time in RFC3339 format (UTC).",
+		func(_ context.Context, _ map[string]interface{}) (interface{}, error) {
+			return time.Now().UTC().Format(time.RFC3339), nil
+		},
+	)
+}
+
+func addTool() tools.Tool {
+	return tools.NewTool(
+		"add",
+		"Adds two numbers and returns their sum.",
+		func(_ context.Context, args map[string]interface{}) (interface{}, error) {
+			a, err := asFloat(args["a"])
+			if err != nil {
+				return nil, fmt.Errorf("a: %w", err)
+			}
+			b, err := asFloat(args["b"])
+			if err != nil {
+				return nil, fmt.Errorf("b: %w", err)
+			}
+			return a + b, nil
+		},
+		tools.Param{Name: "a", Type: "number", Description: "First addend.", Required: true},
+		tools.Param{Name: "b", Type: "number", Description: "Second addend.", Required: true},
+	)
+}
+
+func httpGetTool() tools.Tool {
+	return tools.NewTool(
+		"http_get",
+		"Performs an HTTP GET request and returns the response body (truncated to 8KB).",
+		func(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+			url, _ := args["url"].(string)
+			if url == "" {
+				return nil, fmt.Errorf("the 'url' argument is required")
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if err != nil {
+				return nil, err
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return nil, err
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(io.LimitReader(resp.Body, 8*1024))
+			if err != nil {
+				return nil, err
+			}
+			return string(body), nil
+		},
+		tools.Param{Name: "url", Type: "string", Description: "The URL to fetch.", Required: true},
+	)
+}
+
+func asFloat(v interface{}) (float64, error) {
+	switch n := v.(type) {
+	case float64:
+		return n, nil
+	case float32:
+		return float64(n), nil
+	case int:
+		return float64(n), nil
+	case int64:
+		return float64(n), nil
+	default:
+		return 0, fmt.Errorf("expected a number, got %T", v)
+	}
+}

--- a/cmd/eve/builtins_test.go
+++ b/cmd/eve/builtins_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestValidatePublicURLRejectsLocalAndBadScheme(t *testing.T) {
+	// IP literals don't require DNS, so these are offline-safe.
+	bad := []string{
+		"http://127.0.0.1/",       // loopback
+		"http://169.254.169.254/", // link-local (cloud metadata)
+		"http://[::1]/",           // loopback v6
+		"http://10.0.0.1/",        // private
+		"http://0.0.0.0/",         // unspecified
+		"ftp://example.com/",      // bad scheme
+		"file:///etc/passwd",      // bad scheme
+		"http:///nohost",          // no host
+		"not a url",               // unparseable / no scheme
+	}
+	for _, raw := range bad {
+		if err := validatePublicURL(raw); err == nil {
+			t.Errorf("validatePublicURL(%q) = nil, want error", raw)
+		}
+	}
+}

--- a/cmd/eve/main.go
+++ b/cmd/eve/main.go
@@ -245,7 +245,7 @@ func skillNames(a *agents.Agent) string {
 func handoffNames(a *agents.Agent) string {
 	var names []string
 	for _, h := range a.Handoffs {
-		names = append(names, h.Name)
+		names = append(names, fmt.Sprintf("%s (%s)", h.Name, a.GetHandoffMode(h.Name)))
 	}
 	return strings.Join(names, ", ")
 }

--- a/cmd/eve/main.go
+++ b/cmd/eve/main.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
@@ -21,16 +22,29 @@ import (
 	"github.com/ryanhill4L/agents-sdk/pkg/loader"
 	"github.com/ryanhill4L/agents-sdk/pkg/providers"
 	"github.com/ryanhill4L/agents-sdk/pkg/schedules"
+	"github.com/ryanhill4L/agents-sdk/pkg/tracing"
 )
 
+// verbose enables debug logging + console tracing (set by -v/--verbose).
+var verbose bool
+
 func main() {
-	if len(os.Args) < 2 {
+	// Strip the global -v/--verbose flag from anywhere in the args.
+	var filtered []string
+	for _, a := range os.Args[1:] {
+		if a == "-v" || a == "--verbose" {
+			verbose = true
+			continue
+		}
+		filtered = append(filtered, a)
+	}
+	if len(filtered) == 0 {
 		usage()
 		os.Exit(2)
 	}
 
-	cmd := os.Args[1]
-	args := os.Args[2:]
+	cmd := filtered[0]
+	args := filtered[1:]
 
 	var err error
 	switch cmd {
@@ -69,26 +83,59 @@ Usage:
   eve dev <dir> [addr]    Serve the agent over HTTP (default :8080)
   eve schedules <dir>     Run the agent's cron schedules
 
+Flags:
+  -v, --verbose           Enable debug logging and console tracing
+
 Environment:
   PROVIDER                openai | anthropic | gemini | ollama (else auto-detect)
   OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, OLLAMA_HOST
+  EVE_LOG                 debug | info | warn | error (structured logs to stderr)
+  EVE_TRACE               set to any value to enable console tracing
 `)
 }
 
 // loadAgent loads the agent at dir using the CLI's builtin tool registry,
 // connecting any declared MCP servers. Callers should defer agent.Close().
 func loadAgent(dir string) (*agents.Agent, error) {
-	return loader.Load(dir, builtinRegistry())
+	return loader.LoadWithOptions(dir, builtinRegistry(), loader.Options{Logger: buildLogger()})
 }
 
 // newRunner builds a Runner whose provider is resolved from the agent's
-// declared provider (or the environment).
+// declared provider (or the environment), with logging/tracing per flags/env.
 func newRunner(agent *agents.Agent) (*agents.Runner, error) {
 	provider, err := providers.Resolve(agent.Provider)
 	if err != nil {
 		return nil, err
 	}
-	return agents.NewRunner(agents.WithProvider(provider)), nil
+	opts := []agents.RunnerOption{agents.WithProvider(provider)}
+	if logger := buildLogger(); logger != nil {
+		opts = append(opts, agents.WithLogger(logger))
+	}
+	if tracer := buildTracer(); tracer != nil {
+		opts = append(opts, agents.WithTracer(tracer))
+	}
+	return agents.NewRunner(opts...), nil
+}
+
+// buildLogger returns a stderr logger when -v/--verbose or EVE_LOG is set,
+// otherwise nil (the SDK then discards logs).
+func buildLogger() *slog.Logger {
+	level := os.Getenv("EVE_LOG")
+	if verbose {
+		level = "debug"
+	}
+	if level == "" {
+		return nil
+	}
+	return tracing.NewLogger(os.Stderr, tracing.ParseLevel(level))
+}
+
+// buildTracer returns a console tracer when -v/--verbose or EVE_TRACE is set.
+func buildTracer() tracing.Tracer {
+	if verbose || os.Getenv("EVE_TRACE") != "" {
+		return tracing.NewConsoleTracer()
+	}
+	return nil
 }
 
 func cmdValidate(args []string) error {
@@ -96,7 +143,7 @@ func cmdValidate(args []string) error {
 		return fmt.Errorf("usage: eve validate <dir>")
 	}
 	// Skip connecting to MCP servers so validate stays offline.
-	agent, err := loader.LoadWithOptions(args[0], builtinRegistry(), loader.Options{SkipMCP: true})
+	agent, err := loader.LoadWithOptions(args[0], builtinRegistry(), loader.Options{SkipMCP: true, Logger: buildLogger()})
 	if err != nil {
 		return err
 	}

--- a/cmd/eve/main.go
+++ b/cmd/eve/main.go
@@ -1,0 +1,251 @@
+// Command eve is the CLI for the Eve-inspired, filesystem-first agent framework.
+//
+//	eve init <dir>        scaffold a new agent directory
+//	eve validate <dir>    load an agent and report what was found
+//	eve run <dir> [input] run the agent once and print its reply
+//	eve dev <dir>         serve the agent over HTTP (POST /chat)
+//	eve schedules <dir>   run the agent's cron schedules
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/agents"
+	"github.com/ryanhill4L/agents-sdk/pkg/channels"
+	"github.com/ryanhill4L/agents-sdk/pkg/loader"
+	"github.com/ryanhill4L/agents-sdk/pkg/providers"
+	"github.com/ryanhill4L/agents-sdk/pkg/schedules"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+
+	cmd := os.Args[1]
+	args := os.Args[2:]
+
+	var err error
+	switch cmd {
+	case "init":
+		err = cmdInit(args)
+	case "validate":
+		err = cmdValidate(args)
+	case "run":
+		err = cmdRun(args)
+	case "dev", "serve":
+		err = cmdDev(args)
+	case "schedules":
+		err = cmdSchedules(args)
+	case "help", "-h", "--help":
+		usage()
+		return
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", cmd)
+		usage()
+		os.Exit(2)
+	}
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `eve — filesystem-first AI agents in Go
+
+Usage:
+  eve init <dir>          Scaffold a new agent directory
+  eve validate <dir>      Load an agent and report what was found
+  eve run <dir> [input]   Run the agent once (reads stdin if input omitted)
+  eve dev <dir> [addr]    Serve the agent over HTTP (default :8080)
+  eve schedules <dir>     Run the agent's cron schedules
+
+Environment:
+  PROVIDER                openai | anthropic | gemini | ollama (else auto-detect)
+  OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, OLLAMA_HOST
+`)
+}
+
+// loadAgent loads the agent at dir using the CLI's builtin tool registry.
+func loadAgent(dir string) (*agents.Agent, error) {
+	return loader.Load(dir, builtinRegistry())
+}
+
+// newRunner builds a Runner whose provider is resolved from the agent's
+// declared provider (or the environment).
+func newRunner(agent *agents.Agent) (*agents.Runner, error) {
+	provider, err := providers.Resolve(agent.Provider)
+	if err != nil {
+		return nil, err
+	}
+	return agents.NewRunner(agents.WithProvider(provider)), nil
+}
+
+func cmdValidate(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: eve validate <dir>")
+	}
+	agent, err := loadAgent(args[0])
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ agent %q is valid\n", agent.Name)
+	fmt.Printf("  model:     %s\n", orNone(agent.Model))
+	fmt.Printf("  provider:  %s\n", orNone(agent.Provider))
+	fmt.Printf("  tools:     %s\n", orNone(toolNames(agent)))
+	fmt.Printf("  skills:    %s\n", orNone(skillNames(agent)))
+	fmt.Printf("  subagents: %s\n", orNone(handoffNames(agent)))
+	return nil
+}
+
+func cmdRun(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: eve run <dir> [input]")
+	}
+	agent, err := loadAgent(args[0])
+	if err != nil {
+		return err
+	}
+
+	input := strings.Join(args[1:], " ")
+	if input == "" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		input = strings.TrimSpace(string(data))
+	}
+	if input == "" {
+		return fmt.Errorf("no input provided")
+	}
+
+	runner, err := newRunner(agent)
+	if err != nil {
+		return err
+	}
+
+	result, err := runner.Run(context.Background(), agent, input)
+	if err != nil {
+		return err
+	}
+	fmt.Println(result.FinalOutput)
+	return nil
+}
+
+func cmdDev(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: eve dev <dir> [addr]")
+	}
+	addr := ":8080"
+	if len(args) > 1 {
+		addr = args[1]
+	}
+
+	agent, err := loadAgent(args[0])
+	if err != nil {
+		return err
+	}
+	runner, err := newRunner(agent)
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	channel := channels.NewHTTPChannel(addr)
+	fmt.Printf("eve dev: serving agent %q on %s\n", agent.Name, addr)
+	fmt.Printf("  curl -s localhost%s/chat -d '{\"input\":\"hello\"}'\n", addr)
+
+	return channel.Start(ctx, func(ctx context.Context, input string) (string, error) {
+		result, err := runner.Run(ctx, agent, input)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%v", result.FinalOutput), nil
+	})
+}
+
+func cmdSchedules(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: eve schedules <dir>")
+	}
+	agent, err := loadAgent(args[0])
+	if err != nil {
+		return err
+	}
+	scheds, err := schedules.LoadDir(agent.Dir + "/" + loader.SchedulesDir)
+	if err != nil {
+		return err
+	}
+	if len(scheds) == 0 {
+		return fmt.Errorf("no schedules found in %s/%s", agent.Dir, loader.SchedulesDir)
+	}
+	runner, err := newRunner(agent)
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	fmt.Printf("eve schedules: running %d schedule(s) for agent %q\n", len(scheds), agent.Name)
+	for _, s := range scheds {
+		fmt.Printf("  - %s: %q\n", s.Name, s.Cron)
+	}
+
+	err = schedules.Run(ctx, scheds, func(ctx context.Context, s schedules.Schedule) error {
+		fmt.Printf("[%s] triggering: %s\n", s.Name, s.Input)
+		result, runErr := runner.Run(ctx, agent, s.Input)
+		if runErr != nil {
+			fmt.Fprintf(os.Stderr, "[%s] error: %v\n", s.Name, runErr)
+			return nil // keep the scheduler alive
+		}
+		fmt.Printf("[%s] %v\n", s.Name, result.FinalOutput)
+		return nil
+	})
+	if err == context.Canceled {
+		return nil
+	}
+	return err
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	return s
+}
+
+func toolNames(a *agents.Agent) string {
+	var names []string
+	for _, t := range a.Tools {
+		names = append(names, t.Name())
+	}
+	return strings.Join(names, ", ")
+}
+
+func skillNames(a *agents.Agent) string {
+	var names []string
+	for _, s := range a.Skills {
+		names = append(names, s.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+func handoffNames(a *agents.Agent) string {
+	var names []string
+	for _, h := range a.Handoffs {
+		names = append(names, h.Name)
+	}
+	return strings.Join(names, ", ")
+}

--- a/cmd/eve/main.go
+++ b/cmd/eve/main.go
@@ -75,7 +75,8 @@ Environment:
 `)
 }
 
-// loadAgent loads the agent at dir using the CLI's builtin tool registry.
+// loadAgent loads the agent at dir using the CLI's builtin tool registry,
+// connecting any declared MCP servers. Callers should defer agent.Close().
 func loadAgent(dir string) (*agents.Agent, error) {
 	return loader.Load(dir, builtinRegistry())
 }
@@ -94,7 +95,8 @@ func cmdValidate(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: eve validate <dir>")
 	}
-	agent, err := loadAgent(args[0])
+	// Skip connecting to MCP servers so validate stays offline.
+	agent, err := loader.LoadWithOptions(args[0], builtinRegistry(), loader.Options{SkipMCP: true})
 	if err != nil {
 		return err
 	}
@@ -104,6 +106,7 @@ func cmdValidate(args []string) error {
 	fmt.Printf("  tools:     %s\n", orNone(toolNames(agent)))
 	fmt.Printf("  skills:    %s\n", orNone(skillNames(agent)))
 	fmt.Printf("  subagents: %s\n", orNone(handoffNames(agent)))
+	fmt.Printf("  mcp:       %s\n", orNone(strings.Join(agent.MCPServers, ", ")))
 	return nil
 }
 
@@ -115,6 +118,7 @@ func cmdRun(args []string) error {
 	if err != nil {
 		return err
 	}
+	defer agent.Close()
 
 	input := strings.Join(args[1:], " ")
 	if input == "" {
@@ -154,6 +158,8 @@ func cmdDev(args []string) error {
 	if err != nil {
 		return err
 	}
+	defer agent.Close()
+
 	runner, err := newRunner(agent)
 	if err != nil {
 		return err
@@ -183,6 +189,8 @@ func cmdSchedules(args []string) error {
 	if err != nil {
 		return err
 	}
+	defer agent.Close()
+
 	scheds, err := schedules.LoadDir(agent.Dir + "/" + loader.SchedulesDir)
 	if err != nil {
 		return err

--- a/cmd/eve/scaffold.go
+++ b/cmd/eve/scaffold.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/loader"
+)
+
+// scaffoldFiles maps a relative path within the new agent directory to its
+// initial contents.
+var scaffoldFiles = map[string]string{
+	loader.ConfigFile: `name: assistant
+provider: openai          # openai | anthropic | gemini | ollama
+model: gpt-4o
+temperature: 0.7
+max_tokens: 1024
+tools:
+  - current_time
+  - add
+`,
+	loader.InstructionsFile: `You are a helpful assistant.
+
+Be concise and friendly. Use the available tools when they help answer the
+user's request, and consult your skills before acting on their topics.
+`,
+	filepath.Join(loader.SkillsDir, "greeting.md"): `---
+name: greeting
+description: How to greet users warmly and set expectations.
+---
+When greeting a user for the first time:
+
+1. Greet them by name if you know it.
+2. Briefly state what you can help with.
+3. Ask an open question to get started.
+`,
+	filepath.Join(loader.SchedulesDir, "daily-standup.yaml"): `name: daily-standup
+cron: "0 9 * * 1-5"   # 09:00, Monday–Friday
+input: "Give me a short motivational message to start the workday."
+`,
+}
+
+func cmdInit(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: eve init <dir>")
+	}
+	dir := args[0]
+
+	if info, err := os.Stat(dir); err == nil && info.IsDir() {
+		if _, err := os.Stat(filepath.Join(dir, loader.ConfigFile)); err == nil {
+			return fmt.Errorf("%s already contains an %s", dir, loader.ConfigFile)
+		}
+	}
+
+	for rel, content := range scaffoldFiles {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Created agent in %s\n", dir)
+	fmt.Println("Next steps:")
+	fmt.Printf("  export OPENAI_API_KEY=...   # or set another provider's key\n")
+	fmt.Printf("  eve run %s \"hello\"\n", dir)
+	fmt.Printf("  eve dev %s\n", dir)
+	return nil
+}

--- a/examples/filesystem-agent/README.md
+++ b/examples/filesystem-agent/README.md
@@ -1,0 +1,60 @@
+# Filesystem-first agent example
+
+This directory shows the Eve-inspired, filesystem-first layout. The agent lives
+entirely in `assistant/` as plain files:
+
+```
+assistant/
+  agent.yaml                     # model, provider, temperature, tools
+  instructions.md                # system prompt
+  skills/
+    weather.md                   # on-demand knowledge (front-matter + body)
+  subagents/
+    researcher/                  # a delegated agent (handoff)
+      agent.yaml
+      instructions.md
+  schedules/
+    morning-brief.yaml           # a cron trigger
+```
+
+## Run it with the `eve` CLI
+
+Build the CLI from the repo root:
+
+```bash
+go build -o eve ./cmd/eve
+```
+
+Then, from the repo root:
+
+```bash
+export OPENAI_API_KEY=...        # or ANTHROPIC_API_KEY / GEMINI_API_KEY / OLLAMA_HOST
+
+# Inspect what was loaded (no API key required):
+./eve validate examples/filesystem-agent/assistant
+
+# Run a single turn:
+./eve run examples/filesystem-agent/assistant "What time is it, and what is 21 + 21?"
+
+# Serve it over HTTP:
+./eve dev examples/filesystem-agent/assistant
+#   curl -s localhost:8080/chat -d '{"input":"hello"}'
+
+# Run its cron schedules:
+./eve schedules examples/filesystem-agent/assistant
+```
+
+## How tools work in Go
+
+Because Go tools are compiled functions, `agent.yaml` references them by name and
+the CLI resolves them against its builtin registry (`current_time`, `add`,
+`http_get`). To use your own Go tools, load the agent from your own program with
+a custom registry:
+
+```go
+reg := tools.NewRegistry()
+reg.MustRegister(myTool)
+agent, _ := loader.Load("examples/filesystem-agent/assistant", reg)
+runner := agents.NewRunner(agents.WithProvider(p))
+result, _ := runner.Run(ctx, agent, "hello")
+```

--- a/examples/filesystem-agent/assistant/agent.yaml
+++ b/examples/filesystem-agent/assistant/agent.yaml
@@ -18,3 +18,14 @@ subagents:
 #   - source: github.com/acme/agent-skills/refunds.md
 #     ref: a1b2c3d4         # commit SHA (required for github sources)
 #     sha256: 9f86d0...     # optional integrity pin
+
+# MCP servers are connected at load time; their tools are added to the agent.
+# mcp:
+#   - name: github             # tools exposed as github_<tool>
+#     transport: stdio
+#     command: ["npx", "-y", "@modelcontextprotocol/server-github"]
+#     env: { GITHUB_TOKEN: "${GITHUB_TOKEN}" }
+#   - name: search
+#     transport: http
+#     url: https://mcp.example.com
+#     headers: { Authorization: "Bearer ${SEARCH_KEY}" }

--- a/examples/filesystem-agent/assistant/agent.yaml
+++ b/examples/filesystem-agent/assistant/agent.yaml
@@ -7,3 +7,14 @@ tools:
   - current_time
   - add
   - http_get
+
+# Per-subagent handoff context mode: shared (default) | fresh | forked.
+subagents:
+  researcher: forked      # researcher gets a copy of context and returns a result
+
+# Remote skills are fetched at load time, pinned by commit SHA + checksum.
+# Local skills in skills/ are always loaded in addition to these.
+# skills:
+#   - source: github.com/acme/agent-skills/refunds.md
+#     ref: a1b2c3d4         # commit SHA (required for github sources)
+#     sha256: 9f86d0...     # optional integrity pin

--- a/examples/filesystem-agent/assistant/agent.yaml
+++ b/examples/filesystem-agent/assistant/agent.yaml
@@ -1,0 +1,9 @@
+name: assistant
+provider: openai          # openai | anthropic | gemini | ollama
+model: gpt-4o
+temperature: 0.7
+max_tokens: 1024
+tools:
+  - current_time
+  - add
+  - http_get

--- a/examples/filesystem-agent/assistant/instructions.md
+++ b/examples/filesystem-agent/assistant/instructions.md
@@ -1,0 +1,10 @@
+You are a helpful, concise assistant.
+
+Use the available tools when they help answer the user's request:
+- `current_time` for the current date and time
+- `add` for arithmetic
+- `http_get` to fetch a URL
+
+Before acting on a topic that one of your skills covers, load that skill first
+with the `load_skill` tool and follow its instructions. When a request is about
+research, hand off to the `researcher` subagent.

--- a/examples/filesystem-agent/assistant/schedules/morning-brief.yaml
+++ b/examples/filesystem-agent/assistant/schedules/morning-brief.yaml
@@ -1,0 +1,3 @@
+name: morning-brief
+cron: "0 8 * * 1-5"   # 08:00, Monday–Friday
+input: "Tell me the current time and give me one productivity tip for the day."

--- a/examples/filesystem-agent/assistant/skills/weather.md
+++ b/examples/filesystem-agent/assistant/skills/weather.md
@@ -1,0 +1,11 @@
+---
+name: weather
+description: How to answer questions about the weather using a public API.
+---
+To answer a weather question:
+
+1. Determine the location the user is asking about.
+2. Use the `http_get` tool to fetch `https://wttr.in/<location>?format=3`.
+3. Summarize the result in one friendly sentence.
+
+If the location is ambiguous, ask the user to clarify before fetching.

--- a/examples/filesystem-agent/assistant/subagents/researcher/agent.yaml
+++ b/examples/filesystem-agent/assistant/subagents/researcher/agent.yaml
@@ -1,0 +1,7 @@
+name: researcher
+provider: openai
+model: gpt-4o
+temperature: 0.4
+max_tokens: 1024
+tools:
+  - http_get

--- a/examples/filesystem-agent/assistant/subagents/researcher/instructions.md
+++ b/examples/filesystem-agent/assistant/subagents/researcher/instructions.md
@@ -1,0 +1,4 @@
+You are a focused research subagent.
+
+Given a topic, fetch relevant pages with `http_get`, then return a short,
+well-sourced summary. Prefer primary sources and always cite the URLs you used.

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/ryanhill4L/agents-sdk
 
-go 1.24.3
+go 1.25.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.9.1
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.32
+	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/ollama/ollama v0.11.5
 	github.com/openai/openai-go v1.12.0
 	golang.org/x/sync v0.16.0
@@ -19,17 +20,22 @@ require (
 	cloud.google.com/go/compute/metadata v0.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/s2a-go v0.1.8 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
-	golang.org/x/sys v0.34.0 // indirect
+	golang.org/x/oauth2 v0.35.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/grpc v1.66.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/ollama/ollama v0.11.5
 	github.com/openai/openai-go v1.12.0
-	golang.org/x/sync v0.16.0
 	google.golang.org/genai v1.21.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/openai/openai-go v1.12.0
 	golang.org/x/sync v0.16.0
 	google.golang.org/genai v1.21.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
@@ -40,6 +42,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/s2a-go v0.1.8 h1:zZDs9gcbt9ZPLV0ndSyQk6Kacx2g/X+SKYovpnz3SMM=
 github.com/google/s2a-go v0.1.8/go.mod h1:6iNWHTpQ+nfNRN5E00MSdfDwVesa8hhS32PhPO8deJA=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -51,6 +55,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
+github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/ollama/ollama v0.11.5 h1:mtiPW4nOvdQyNo4PGKbslIcD0JD75IORCZqMdj/qd4Y=
 github.com/ollama/ollama v0.11.5/go.mod h1:9+1//yWPsDE2u+l1a5mpaKrYw4VdnSsRU3ioq5BvMms=
 github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
@@ -58,6 +64,10 @@ github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefw
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -76,6 +86,8 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -95,6 +107,8 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
 golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -104,8 +118,8 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
-golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.33.0 h1:NuFncQrRcaRvVmgRkvM3j/F00gWIAlcmlB8ACEKmGIg=
 golang.org/x/term v0.33.0/go.mod h1:s18+ql9tYWp1IfpV9DmCtQDDSRBUjKaw9M1eAv5UeF0=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -117,6 +131,8 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
+golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/pkg/agents/agent.go
+++ b/pkg/agents/agent.go
@@ -2,9 +2,11 @@ package agents
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/ryanhill4L/agents-sdk/pkg/guardrails"
+	"github.com/ryanhill4L/agents-sdk/pkg/skills"
 	"github.com/ryanhill4L/agents-sdk/pkg/tools"
 )
 
@@ -21,6 +23,14 @@ type Agent struct {
 	Tools      []tools.Tool
 	Handoffs   []*Agent
 	Guardrails []guardrails.Guardrail
+	Skills     []skills.Skill
+
+	// Provider names the LLM backend (openai, anthropic, gemini, ollama).
+	// It is advisory: a Runner with an explicit provider always wins.
+	Provider string
+
+	// Dir records the directory an agent was loaded from, when applicable.
+	Dir string
 
 	// Configuration
 	OutputType  OutputSchema
@@ -113,7 +123,35 @@ func (a *Agent) GetName() string {
 }
 
 func (a *Agent) GetInstructions() string {
-	return a.Instructions
+	if len(a.Skills) == 0 {
+		return a.Instructions
+	}
+	catalog := skills.Catalog(a.Skills)
+	if a.Instructions == "" {
+		return catalog
+	}
+	return strings.TrimRight(a.Instructions, "\n") + "\n\n" + catalog
+}
+
+// EffectiveTools returns the agent's tools plus the builtin load_skill tool when
+// the agent has skills. This is what the Runner exposes to the model so that
+// skills can be pulled on demand.
+func (a *Agent) EffectiveTools() []tools.Tool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	if len(a.Skills) == 0 {
+		return a.Tools
+	}
+	for _, t := range a.Tools {
+		if t.Name() == skills.LoadSkillToolName {
+			return a.Tools // already present
+		}
+	}
+	effective := make([]tools.Tool, 0, len(a.Tools)+1)
+	effective = append(effective, a.Tools...)
+	effective = append(effective, skills.NewLoadSkillTool(a.Skills))
+	return effective
 }
 
 func (a *Agent) GetModel() string {
@@ -141,12 +179,17 @@ func (a *Agent) Clone() *Agent {
 		Name:         a.Name,
 		Instructions: a.Instructions,
 		Model:        a.Model,
+		Provider:     a.Provider,
+		Dir:          a.Dir,
 		OutputType:   a.OutputType,
 		Temperature:  a.Temperature,
 		MaxTokens:    a.MaxTokens,
 		TopP:         a.TopP,
 		handoffMap:   make(map[string]*Agent),
 	}
+
+	clone.Skills = make([]skills.Skill, len(a.Skills))
+	copy(clone.Skills, a.Skills)
 
 	// Deep copy tools
 	clone.Tools = make([]tools.Tool, len(a.Tools))

--- a/pkg/agents/agent.go
+++ b/pkg/agents/agent.go
@@ -39,7 +39,8 @@ type Agent struct {
 	TopP        float32
 
 	// Runtime
-	handoffMap map[string]*Agent
+	handoffMap   map[string]*Agent
+	handoffModes map[string]HandoffMode
 }
 
 // NewAgent creates a new agent with the given name and options
@@ -49,8 +50,9 @@ func NewAgent(name string, opts ...AgentOption) *Agent {
 		Model:       "gpt-4",
 		Temperature: 0.7,
 		MaxTokens:   2000,
-		TopP:        1.0,
-		handoffMap:  make(map[string]*Agent),
+		TopP:         1.0,
+		handoffMap:   make(map[string]*Agent),
+		handoffModes: make(map[string]HandoffMode),
 	}
 
 	for _, opt := range opts {
@@ -133,24 +135,33 @@ func (a *Agent) GetInstructions() string {
 	return strings.TrimRight(a.Instructions, "\n") + "\n\n" + catalog
 }
 
-// EffectiveTools returns the agent's tools plus the builtin load_skill tool when
-// the agent has skills. This is what the Runner exposes to the model so that
-// skills can be pulled on demand.
+// EffectiveTools returns the agent's tools plus the builtins the Runner exposes
+// to the model: load_skill (when the agent has skills) and one handoff tool per
+// subagent. The Runner intercepts handoff tool calls.
 func (a *Agent) EffectiveTools() []tools.Tool {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
-	if len(a.Skills) == 0 {
-		return a.Tools
-	}
+	present := make(map[string]bool, len(a.Tools))
 	for _, t := range a.Tools {
-		if t.Name() == skills.LoadSkillToolName {
-			return a.Tools // already present
-		}
+		present[t.Name()] = true
 	}
-	effective := make([]tools.Tool, 0, len(a.Tools)+1)
-	effective = append(effective, a.Tools...)
-	effective = append(effective, skills.NewLoadSkillTool(a.Skills))
+
+	effective := make([]tools.Tool, len(a.Tools))
+	copy(effective, a.Tools)
+
+	if len(a.Skills) > 0 && !present[skills.LoadSkillToolName] {
+		effective = append(effective, skills.NewLoadSkillTool(a.Skills))
+	}
+
+	for _, h := range a.Handoffs {
+		name := handoffToolName(h.Name)
+		if present[name] {
+			continue
+		}
+		effective = append(effective, newHandoffTool(h, a.handoffModes[h.Name]))
+	}
+
 	return effective
 }
 
@@ -186,10 +197,15 @@ func (a *Agent) Clone() *Agent {
 		MaxTokens:    a.MaxTokens,
 		TopP:         a.TopP,
 		handoffMap:   make(map[string]*Agent),
+		handoffModes: make(map[string]HandoffMode),
 	}
 
 	clone.Skills = make([]skills.Skill, len(a.Skills))
 	copy(clone.Skills, a.Skills)
+
+	for k, v := range a.handoffModes {
+		clone.handoffModes[k] = v
+	}
 
 	// Deep copy tools
 	clone.Tools = make([]tools.Tool, len(a.Tools))

--- a/pkg/agents/agent.go
+++ b/pkg/agents/agent.go
@@ -57,8 +57,18 @@ func (a *Agent) AddCloser(c io.Closer) {
 }
 
 // Close releases the agent's resources and those of its subagents. It is safe
-// to call on agents with nothing to close.
+// to call on agents with nothing to close, and on graphs that share or cycle
+// through subagents (each agent is closed at most once).
 func (a *Agent) Close() error {
+	return a.closeTree(make(map[*Agent]bool))
+}
+
+func (a *Agent) closeTree(visited map[*Agent]bool) error {
+	if visited[a] {
+		return nil
+	}
+	visited[a] = true
+
 	a.mu.Lock()
 	closers := a.closers
 	a.closers = nil
@@ -72,7 +82,7 @@ func (a *Agent) Close() error {
 		}
 	}
 	for _, h := range handoffs {
-		if err := h.Close(); err != nil && firstErr == nil {
+		if err := h.closeTree(visited); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}

--- a/pkg/agents/agent.go
+++ b/pkg/agents/agent.go
@@ -2,6 +2,7 @@ package agents
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 
@@ -32,6 +33,9 @@ type Agent struct {
 	// Dir records the directory an agent was loaded from, when applicable.
 	Dir string
 
+	// MCPServers names the MCP servers declared for this agent (for reporting).
+	MCPServers []string
+
 	// Configuration
 	OutputType  OutputSchema
 	Temperature float32
@@ -41,15 +45,47 @@ type Agent struct {
 	// Runtime
 	handoffMap   map[string]*Agent
 	handoffModes map[string]HandoffMode
+	closers      []io.Closer
+}
+
+// AddCloser registers a resource (e.g. an MCP connection) to be released when
+// the agent is closed.
+func (a *Agent) AddCloser(c io.Closer) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.closers = append(a.closers, c)
+}
+
+// Close releases the agent's resources and those of its subagents. It is safe
+// to call on agents with nothing to close.
+func (a *Agent) Close() error {
+	a.mu.Lock()
+	closers := a.closers
+	a.closers = nil
+	handoffs := a.Handoffs
+	a.mu.Unlock()
+
+	var firstErr error
+	for _, c := range closers {
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	for _, h := range handoffs {
+		if err := h.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // NewAgent creates a new agent with the given name and options
 func NewAgent(name string, opts ...AgentOption) *Agent {
 	agent := &Agent{
-		Name:        name,
-		Model:       "gpt-4",
-		Temperature: 0.7,
-		MaxTokens:   2000,
+		Name:         name,
+		Model:        "gpt-4",
+		Temperature:  0.7,
+		MaxTokens:    2000,
 		TopP:         1.0,
 		handoffMap:   make(map[string]*Agent),
 		handoffModes: make(map[string]HandoffMode),

--- a/pkg/agents/close_test.go
+++ b/pkg/agents/close_test.go
@@ -1,0 +1,32 @@
+package agents
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+type countingCloser struct{ closes int32 }
+
+func (c *countingCloser) Close() error {
+	atomic.AddInt32(&c.closes, 1)
+	return nil
+}
+
+func TestCloseDiamondClosesOnce(t *testing.T) {
+	// shared is reachable through two parents (a diamond). Its closer must run
+	// exactly once, and Close must not recurse forever.
+	shared := NewAgent("shared")
+	closer := &countingCloser{}
+	shared.AddCloser(closer)
+
+	left := NewAgent("left", WithHandoffs(shared))
+	right := NewAgent("right", WithHandoffs(shared))
+	root := NewAgent("root", WithHandoffs(left, right))
+
+	if err := root.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := atomic.LoadInt32(&closer.closes); got != 1 {
+		t.Errorf("shared closer ran %d times, want 1", got)
+	}
+}

--- a/pkg/agents/handoff.go
+++ b/pkg/agents/handoff.go
@@ -1,0 +1,179 @@
+package agents
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/tools"
+)
+
+// pendingHandoff captures a handoff tool call the runner needs to act on.
+type pendingHandoff struct {
+	call ToolCall
+	sub  *Agent
+	mode HandoffMode
+	task string
+}
+
+// toolMessage builds a tool-result message for the given tool call id.
+func toolMessage(toolCallID, content string) Message {
+	return Message{
+		Role:      "tool",
+		Content:   content,
+		Timestamp: time.Now(),
+		Metadata:  map[string]interface{}{"tool_call_id": toolCallID},
+	}
+}
+
+// toolContent renders a tool response (or its error) as message content.
+func toolContent(resp ToolResponse) string {
+	if resp.Error != nil {
+		return fmt.Sprintf("Error: %v", resp.Error)
+	}
+	return fmt.Sprintf("%v", resp.Content)
+}
+
+// buildHandoffMessages constructs the message list a delegated subagent runs
+// with. history is the parent conversation up to (but excluding) the assistant
+// turn that triggered the handoff.
+func buildHandoffMessages(mode HandoffMode, history []Message, task string) []Message {
+	switch mode {
+	case ContextForked:
+		forked := make([]Message, len(history))
+		copy(forked, history)
+		if task != "" {
+			forked = append(forked, Message{Role: "user", Content: task, Timestamp: time.Now()})
+		}
+		return forked
+	default: // ContextFresh
+		if task == "" {
+			task = lastUserContent(history)
+		}
+		return []Message{{Role: "user", Content: task, Timestamp: time.Now()}}
+	}
+}
+
+// lastUserContent returns the content of the most recent user message.
+func lastUserContent(messages []Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "user" {
+			return messages[i].Content
+		}
+	}
+	return ""
+}
+
+// HandoffMode controls how context is passed when an agent hands off to a
+// subagent, and whether control returns to the parent.
+type HandoffMode int
+
+const (
+	// ContextShared transfers control to the subagent, which continues with the
+	// parent's full live conversation. Control does not return to the parent.
+	// This is the default and matches a classic "you take it from here" handoff.
+	ContextShared HandoffMode = iota
+
+	// ContextFresh delegates a task to the subagent in a clean context (it sees
+	// only the task, no parent history). The subagent's result is returned to
+	// the parent, which then resumes. Use when you want isolation with no
+	// context bleed.
+	ContextFresh
+
+	// ContextForked delegates to the subagent with a copy of the parent's
+	// conversation, so it has full context but runs independently. Its result is
+	// returned to the parent, which resumes unaffected. Use for independent
+	// exploration that shouldn't mutate the parent's state.
+	ContextForked
+)
+
+// String returns the lowercase name of the mode.
+func (m HandoffMode) String() string {
+	switch m {
+	case ContextShared:
+		return "shared"
+	case ContextFresh:
+		return "fresh"
+	case ContextForked:
+		return "forked"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseHandoffMode converts a string (shared/fresh/forked, empty = shared) to a
+// HandoffMode.
+func ParseHandoffMode(s string) (HandoffMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "shared":
+		return ContextShared, nil
+	case "fresh":
+		return ContextFresh, nil
+	case "forked":
+		return ContextForked, nil
+	default:
+		return ContextShared, fmt.Errorf("unknown handoff mode %q (want shared, fresh, or forked)", s)
+	}
+}
+
+// handoffToolName derives the deterministic tool name a model calls to hand off
+// to the named subagent.
+func handoffToolName(agentName string) string {
+	var b strings.Builder
+	b.WriteString("handoff_")
+	for _, r := range strings.ToLower(agentName) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// HandoffForTool resolves a handoff tool-call name to its target subagent and
+// mode. It reports false when toolName is not a handoff tool for this agent.
+func (a *Agent) HandoffForTool(toolName string) (*Agent, HandoffMode, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	for _, h := range a.Handoffs {
+		if handoffToolName(h.Name) == toolName {
+			return h, a.handoffModes[h.Name], true
+		}
+	}
+	return nil, ContextShared, false
+}
+
+// GetHandoffMode returns the configured mode for a handoff target (defaults to
+// ContextShared).
+func (a *Agent) GetHandoffMode(name string) HandoffMode {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.handoffModes[name]
+}
+
+// newHandoffTool builds the tool a model calls to hand off to sub. The runner
+// intercepts calls to this tool, so its handler is only a safe fallback.
+func newHandoffTool(sub *Agent, mode HandoffMode) tools.Tool {
+	desc := fmt.Sprintf(
+		"Hand off to the %q subagent (%s context). Use this when the request is better handled by that agent. Provide the task or reason in 'task'.",
+		sub.Name, mode,
+	)
+	return tools.NewTool(
+		handoffToolName(sub.Name),
+		desc,
+		func(_ context.Context, args map[string]interface{}) (interface{}, error) {
+			task, _ := args["task"].(string)
+			return fmt.Sprintf("Handing off to %s: %s", sub.Name, task), nil
+		},
+		tools.Param{
+			Name:        "task",
+			Type:        "string",
+			Description: "The task or reason for the handoff.",
+			Required:    true,
+		},
+	)
+}

--- a/pkg/agents/handoff_test.go
+++ b/pkg/agents/handoff_test.go
@@ -1,0 +1,140 @@
+package agents
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/providers"
+)
+
+// scriptedProvider returns canned completions keyed by agent name and call
+// count, and records the messages each agent was invoked with.
+type scriptedProvider struct {
+	mu       sync.Mutex
+	calls    map[string]int
+	seenMsgs map[string][]providers.Message
+}
+
+func newScriptedProvider() *scriptedProvider {
+	return &scriptedProvider{calls: map[string]int{}, seenMsgs: map[string][]providers.Message{}}
+}
+
+func (p *scriptedProvider) Complete(_ context.Context, agent providers.Agent, messages []providers.Message, _ []providers.ToolDefinition) (*providers.Completion, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	name := agent.GetName()
+	n := p.calls[name]
+	p.calls[name]++
+	if _, ok := p.seenMsgs[name]; !ok {
+		p.seenMsgs[name] = messages
+	}
+
+	switch name {
+	case "router":
+		if n == 0 {
+			return &providers.Completion{
+				Message: providers.Message{Role: "assistant"},
+				ToolCalls: []providers.ToolCall{{
+					ID:        "call_1",
+					Name:      "handoff_worker",
+					Arguments: map[string]interface{}{"task": "do the thing"},
+				}},
+			}, nil
+		}
+		return &providers.Completion{Message: providers.Message{Role: "assistant", Content: "router final"}}, nil
+	case "worker":
+		return &providers.Completion{Message: providers.Message{Role: "assistant", Content: "worker handled it"}}, nil
+	default:
+		return &providers.Completion{Message: providers.Message{Role: "assistant", Content: "?"}}, nil
+	}
+}
+
+func runHandoff(t *testing.T, mode HandoffMode) (*RunResult, *scriptedProvider) {
+	t.Helper()
+	worker := NewAgent("worker")
+	router := NewAgent("router", WithHandoff(worker, mode))
+
+	provider := newScriptedProvider()
+	runner := NewRunner(WithProvider(provider))
+
+	result, err := runner.Run(context.Background(), router, "start")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return result, provider
+}
+
+func TestHandoffFreshContext(t *testing.T) {
+	result, provider := runHandoff(t, ContextFresh)
+
+	if result.FinalOutput != "router final" {
+		t.Errorf("final output = %v, want 'router final'", result.FinalOutput)
+	}
+	if result.Metrics.Handoffs == 0 {
+		t.Error("expected at least one handoff in metrics")
+	}
+
+	// Fresh: the worker sees only the task, not the parent's history.
+	seen := provider.seenMsgs["worker"]
+	if len(seen) != 1 || seen[0].Content != "do the thing" {
+		t.Errorf("worker context = %+v, want single 'do the thing' message", seen)
+	}
+}
+
+func TestHandoffForkedContext(t *testing.T) {
+	_, provider := runHandoff(t, ContextForked)
+
+	// Forked: the worker sees a copy of the parent history plus the task.
+	seen := provider.seenMsgs["worker"]
+	if len(seen) != 2 {
+		t.Fatalf("worker context length = %d, want 2; msgs=%+v", len(seen), seen)
+	}
+	if seen[0].Content != "start" {
+		t.Errorf("forked context[0] = %q, want 'start'", seen[0].Content)
+	}
+	if seen[1].Content != "do the thing" {
+		t.Errorf("forked context[1] = %q, want 'do the thing'", seen[1].Content)
+	}
+}
+
+func TestHandoffSharedContextTransfersControl(t *testing.T) {
+	result, _ := runHandoff(t, ContextShared)
+
+	// Shared: control transfers to the worker, whose output becomes the result.
+	if result.FinalOutput != "worker handled it" {
+		t.Errorf("final output = %v, want 'worker handled it'", result.FinalOutput)
+	}
+	if result.Agent == nil || result.Agent.Name != "worker" {
+		t.Errorf("final agent = %v, want worker", result.Agent)
+	}
+}
+
+func TestHandoffToolExposed(t *testing.T) {
+	worker := NewAgent("worker")
+	router := NewAgent("router", WithHandoff(worker, ContextFresh))
+
+	var found bool
+	for _, tool := range router.EffectiveTools() {
+		if tool.Name() == "handoff_worker" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected handoff_worker tool in router.EffectiveTools()")
+	}
+}
+
+func TestParseHandoffMode(t *testing.T) {
+	cases := map[string]HandoffMode{"": ContextShared, "shared": ContextShared, "fresh": ContextFresh, "forked": ContextForked}
+	for in, want := range cases {
+		got, err := ParseHandoffMode(in)
+		if err != nil || got != want {
+			t.Errorf("ParseHandoffMode(%q) = %v, %v; want %v", in, got, err, want)
+		}
+	}
+	if _, err := ParseHandoffMode("bogus"); err == nil {
+		t.Error("expected error for bogus mode")
+	}
+}

--- a/pkg/agents/options.go
+++ b/pkg/agents/options.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ryanhill4L/agents-sdk/pkg/guardrails"
 	"github.com/ryanhill4L/agents-sdk/pkg/memory"
 	"github.com/ryanhill4L/agents-sdk/pkg/providers"
+	"github.com/ryanhill4L/agents-sdk/pkg/skills"
 	"github.com/ryanhill4L/agents-sdk/pkg/tools"
 	"github.com/ryanhill4L/agents-sdk/pkg/tracing"
 )
@@ -51,6 +52,22 @@ func WithHandoffs(agents ...*Agent) AgentOption {
 func WithGuardrails(guardrails ...guardrails.Guardrail) AgentOption {
 	return func(a *Agent) {
 		a.Guardrails = append(a.Guardrails, guardrails...)
+	}
+}
+
+// WithSkills adds on-demand skills to the agent. Their catalog is appended to
+// the system prompt and a load_skill tool is exposed so the model can pull a
+// skill's full body when needed.
+func WithSkills(s ...skills.Skill) AgentOption {
+	return func(a *Agent) {
+		a.Skills = append(a.Skills, s...)
+	}
+}
+
+// WithProviderName records the preferred provider name for this agent (advisory).
+func WithProviderName(provider string) AgentOption {
+	return func(a *Agent) {
+		a.Provider = provider
 	}
 }
 

--- a/pkg/agents/options.go
+++ b/pkg/agents/options.go
@@ -35,16 +35,31 @@ func WithTools(tools ...tools.Tool) AgentOption {
 	}
 }
 
-// WithHandoffs adds handoff agents
+// WithHandoffs adds handoff agents using the default ContextShared mode.
 func WithHandoffs(agents ...*Agent) AgentOption {
 	return func(a *Agent) {
 		a.Handoffs = append(a.Handoffs, agents...)
+		rebuildHandoffMap(a)
+	}
+}
 
-		// Rebuild handoff map
-		a.handoffMap = make(map[string]*Agent)
-		for _, handoff := range a.Handoffs {
-			a.handoffMap[handoff.Name] = handoff
+// WithHandoff adds a single handoff target with an explicit context mode
+// (ContextShared, ContextFresh, or ContextForked).
+func WithHandoff(agent *Agent, mode HandoffMode) AgentOption {
+	return func(a *Agent) {
+		a.Handoffs = append(a.Handoffs, agent)
+		if a.handoffModes == nil {
+			a.handoffModes = make(map[string]HandoffMode)
 		}
+		a.handoffModes[agent.Name] = mode
+		rebuildHandoffMap(a)
+	}
+}
+
+func rebuildHandoffMap(a *Agent) {
+	a.handoffMap = make(map[string]*Agent)
+	for _, handoff := range a.Handoffs {
+		a.handoffMap[handoff.Name] = handoff
 	}
 }
 

--- a/pkg/agents/options.go
+++ b/pkg/agents/options.go
@@ -1,6 +1,7 @@
 package agents
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/ryanhill4L/agents-sdk/pkg/guardrails"
@@ -121,6 +122,13 @@ func WithProvider(provider providers.Provider) RunnerOption {
 func WithTracer(tracer tracing.Tracer) RunnerOption {
 	return func(r *Runner) {
 		r.tracer = tracer
+	}
+}
+
+// WithLogger sets the structured logger used for run/turn/tool/handoff events.
+func WithLogger(logger *slog.Logger) RunnerOption {
+	return func(r *Runner) {
+		r.logger = logger
 	}
 }
 

--- a/pkg/agents/runner.go
+++ b/pkg/agents/runner.go
@@ -146,6 +146,10 @@ func (r *Runner) executeLoop(ctx *RunContext, agent *Agent, messages []Message) 
 		}
 
 		metrics.TotalTokens += completion.Usage.TotalTokens
+
+		// turnStart marks the history boundary before this assistant turn, used
+		// to fork a clean context for delegated subagents.
+		turnStart := len(messages)
 		messages = append(messages, messageFromProviders(completion.Message))
 
 		// Check for final output
@@ -161,7 +165,7 @@ func (r *Runner) executeLoop(ctx *RunContext, agent *Agent, messages []Message) 
 			}, nil
 		}
 
-		// Handle handoffs
+		// Handle legacy provider-driven handoffs (transfer of control).
 		if completion.Handoff != nil {
 			metrics.Handoffs++
 
@@ -174,25 +178,61 @@ func (r *Runner) executeLoop(ctx *RunContext, agent *Agent, messages []Message) 
 			continue
 		}
 
-		// Handle tool calls
+		// Handle tool calls, separating handoff tool calls from regular ones.
 		if len(completion.ToolCalls) > 0 {
-			metrics.ToolCalls += len(completion.ToolCalls)
-
-			toolResponses, err := r.executeTools(ctx, currentAgent, toolCallsFromProviders(completion.ToolCalls))
-			if err != nil {
-				return nil, fmt.Errorf("tool execution failed: %w", err)
+			var (
+				normalCalls []ToolCall
+				handoffs    []pendingHandoff
+			)
+			for _, call := range toolCallsFromProviders(completion.ToolCalls) {
+				if sub, mode, ok := currentAgent.HandoffForTool(call.Name); ok {
+					task, _ := call.Arguments["task"].(string)
+					handoffs = append(handoffs, pendingHandoff{call: call, sub: sub, mode: mode, task: task})
+					continue
+				}
+				normalCalls = append(normalCalls, call)
 			}
 
-			// Add tool responses as messages
-			for _, resp := range toolResponses {
-				messages = append(messages, Message{
-					Role:      "tool",
-					Content:   fmt.Sprintf("%v", resp.Content),
-					Timestamp: time.Now(),
-					Metadata: map[string]interface{}{
-						"tool_call_id": resp.ToolCallID,
-					},
-				})
+			if len(normalCalls) > 0 {
+				metrics.ToolCalls += len(normalCalls)
+				toolResponses, err := r.executeTools(ctx, currentAgent, normalCalls)
+				if err != nil {
+					return nil, fmt.Errorf("tool execution failed: %w", err)
+				}
+				for _, resp := range toolResponses {
+					messages = append(messages, toolMessage(resp.ToolCallID, toolContent(resp)))
+				}
+			}
+
+			// Only one handoff is acted on per turn; acknowledge any extras so
+			// their tool calls are still answered.
+			for i := 1; i < len(handoffs); i++ {
+				messages = append(messages, toolMessage(handoffs[i].call.ID,
+					"Ignored: only one handoff is processed per turn."))
+			}
+
+			if len(handoffs) > 0 {
+				h := handoffs[0]
+				metrics.Handoffs++
+
+				if h.mode == ContextShared {
+					messages = append(messages, toolMessage(h.call.ID,
+						fmt.Sprintf("Transferring to %s.", h.sub.Name)))
+					currentAgent = h.sub
+					continue
+				}
+
+				// ContextFresh / ContextForked: delegate and return the result.
+				nested := buildHandoffMessages(h.mode, messages[:turnStart], h.task)
+				subResult, err := r.executeLoop(ctx, h.sub, nested)
+				if err != nil {
+					return nil, fmt.Errorf("subagent %q failed: %w", h.sub.Name, err)
+				}
+				metrics.TotalTokens += subResult.Metrics.TotalTokens
+				metrics.ToolCalls += subResult.Metrics.ToolCalls
+				metrics.Handoffs += subResult.Metrics.Handoffs
+				messages = append(messages, toolMessage(h.call.ID,
+					fmt.Sprintf("%v", subResult.FinalOutput)))
 			}
 
 			continue

--- a/pkg/agents/runner.go
+++ b/pkg/agents/runner.go
@@ -2,7 +2,9 @@ package agents
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -17,6 +19,7 @@ import (
 type Runner struct {
 	provider providers.Provider
 	tracer   tracing.Tracer
+	logger   *slog.Logger
 	session  memory.Session
 
 	maxTurns      int
@@ -26,11 +29,11 @@ type Runner struct {
 
 // RunResult contains the execution results
 type RunResult struct {
-	FinalOutput interface{}    `json:"final_output"`
-	Messages    []Message      `json:"messages"`
-	Agent       *Agent         `json:"-"`
-	Traces      []tracing.Span `json:"traces,omitempty"`
-	Metrics     RunMetrics     `json:"metrics"`
+	FinalOutput interface{}          `json:"final_output"`
+	Messages    []Message            `json:"messages"`
+	Agent       *Agent               `json:"-"`
+	Traces      []tracing.SpanRecord `json:"traces,omitempty"`
+	Metrics     RunMetrics           `json:"metrics"`
 }
 
 // RunMetrics contains execution metrics
@@ -63,27 +66,50 @@ func NewRunner(opts ...RunnerOption) *Runner {
 		r.tracer = tracing.NewNoOpTracer()
 	}
 
+	if r.logger == nil {
+		r.logger = tracing.DiscardLogger()
+	}
+
 	return r
 }
 
 // Run executes the agent workflow asynchronously
-func (r *Runner) Run(ctx context.Context, agent *Agent, input string) (*RunResult, error) {
-	// Create run context
+func (r *Runner) Run(ctx context.Context, agent *Agent, input string) (result *RunResult, err error) {
+	sessionID := uuid.New().String()
+	traceID := uuid.New().String()
+
+	// Tee the configured tracer with a recorder so the trace tree is also
+	// available programmatically via RunResult.Traces.
+	recorder := tracing.NewRecorder()
+	tracer := tracing.NewTee(r.tracer, recorder)
+
+	// Apply timeout, then open the root span.
+	ctx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+
+	ctx, rootSpan := tracing.Start(ctx, tracer, "agent.run",
+		tracing.A("agent", agent.Name),
+		tracing.A("session_id", sessionID),
+		tracing.A("input_chars", len(input)),
+	)
+	// End the root span, then attach the full recorded trace tree to the result.
+	defer func() {
+		rootSpan.End()
+		if result != nil {
+			result.Traces = recorder.Records()
+		}
+	}()
+
+	logger := r.logger.With("agent", agent.Name, "session_id", sessionID, "trace_id", traceID)
+	logger.Info("run started", "input_chars", len(input), "max_turns", r.maxTurns)
+
 	runCtx := &RunContext{
 		Context:   ctx,
-		SessionID: uuid.New().String(),
-		TraceID:   uuid.New().String(),
+		SessionID: sessionID,
+		TraceID:   traceID,
 		MaxTurns:  r.maxTurns,
 		Variables: make(map[string]interface{}),
 	}
-
-	// Start tracing
-	ctx, rootSpan := r.tracer.StartSpan(ctx, "agent.run")
-	defer r.tracer.EndSpan(rootSpan)
-
-	// Apply timeout
-	ctx, cancel := context.WithTimeout(ctx, r.timeout)
-	defer cancel()
 
 	// Initialize messages
 	messages := []Message{
@@ -98,20 +124,41 @@ func (r *Runner) Run(ctx context.Context, agent *Agent, input string) (*RunResul
 	if r.session != nil {
 		history, err := r.session.GetItems(ctx, 100)
 		if err != nil {
+			rootSpan.SetError(err)
+			logger.Error("session load failed", "error", err)
 			return nil, fmt.Errorf("failed to load session: %w", err)
 		}
+		logger.Debug("session history loaded", "messages", len(history))
 		messages = append(messagesFromMemory(history), messages...)
 	}
 
 	// Execute agent loop
-	result, err := r.executeLoop(runCtx, agent, messages)
+	result, err = r.executeLoop(runCtx, tracer, logger, agent, messages)
 	if err != nil {
+		rootSpan.SetError(err)
+		logger.Error("run failed", "error", err)
 		return nil, err
 	}
+
+	rootSpan.SetAttributes(
+		tracing.A("turns", result.Metrics.TotalTurns),
+		tracing.A("tokens", result.Metrics.TotalTokens),
+		tracing.A("tool_calls", result.Metrics.ToolCalls),
+		tracing.A("handoffs", result.Metrics.Handoffs),
+	)
+	logger.Info("run completed",
+		"turns", result.Metrics.TotalTurns,
+		"tokens", result.Metrics.TotalTokens,
+		"tool_calls", result.Metrics.ToolCalls,
+		"handoffs", result.Metrics.Handoffs,
+		"duration", result.Metrics.Duration,
+	)
 
 	// Save to session
 	if r.session != nil {
 		if err := r.session.AddItems(ctx, messagesToMemory(result.Messages)); err != nil {
+			rootSpan.SetError(err)
+			logger.Error("session save failed", "error", err)
 			return nil, fmt.Errorf("failed to save session: %w", err)
 		}
 	}
@@ -119,8 +166,9 @@ func (r *Runner) Run(ctx context.Context, agent *Agent, input string) (*RunResul
 	return result, nil
 }
 
-// executeLoop runs the main agent execution loop
-func (r *Runner) executeLoop(ctx *RunContext, agent *Agent, messages []Message) (*RunResult, error) {
+// executeLoop runs the main agent execution loop. Each turn is wrapped in a
+// span (via a closure so the span is always ended), and emits structured logs.
+func (r *Runner) executeLoop(ctx *RunContext, tracer tracing.Tracer, logger *slog.Logger, agent *Agent, messages []Message) (*RunResult, error) {
 	startTime := time.Now()
 	metrics := RunMetrics{}
 	currentAgent := agent
@@ -128,189 +176,234 @@ func (r *Runner) executeLoop(ctx *RunContext, agent *Agent, messages []Message) 
 	for turn := 0; turn < ctx.MaxTurns; turn++ {
 		ctx.CurrentTurn = turn
 
-		// Check context cancellation
 		if err := ctx.Err(); err != nil {
 			return nil, fmt.Errorf("context cancelled: %w", err)
 		}
 
-		// Validate input with guardrails
-		if err := r.validateGuardrails(currentAgent, messages); err != nil {
-			return nil, fmt.Errorf("guardrail validation failed: %w", err)
-		}
+		var (
+			result    *RunResult
+			nextAgent *Agent
+		)
 
-		// Get LLM completion
-		toolDefs := convertToolsToProviders(currentAgent.EffectiveTools())
-		completion, err := r.provider.Complete(ctx.Context, currentAgent, messagesToProviders(messages), toolDefs)
-		if err != nil {
-			return nil, fmt.Errorf("completion failed: %w", err)
-		}
+		turnErr := func() error {
+			turnCtx, turnSpan := tracing.Start(ctx.Context, tracer, "turn",
+				tracing.A("n", turn), tracing.A("agent", currentAgent.Name))
+			defer turnSpan.End()
 
-		metrics.TotalTokens += completion.Usage.TotalTokens
-
-		// turnStart marks the history boundary before this assistant turn, used
-		// to fork a clean context for delegated subagents.
-		turnStart := len(messages)
-		messages = append(messages, messageFromProviders(completion.Message))
-
-		// Check for final output
-		if currentAgent.OutputType != nil && completion.StructuredOutput != nil {
-			metrics.Duration = time.Since(startTime)
-			metrics.TotalTurns = turn + 1
-
-			return &RunResult{
-				FinalOutput: completion.StructuredOutput,
-				Messages:    messages,
-				Agent:       currentAgent,
-				Metrics:     metrics,
-			}, nil
-		}
-
-		// Handle legacy provider-driven handoffs (transfer of control).
-		if completion.Handoff != nil {
-			metrics.Handoffs++
-
-			newAgent, ok := currentAgent.GetHandoff(completion.Handoff.TargetAgent)
-			if !ok {
-				return nil, fmt.Errorf("handoff agent not found: %s", completion.Handoff.TargetAgent)
+			// Guardrails
+			if err := r.validateGuardrails(turnCtx, tracer, logger, currentAgent, messages); err != nil {
+				turnSpan.SetError(err)
+				return fmt.Errorf("guardrail validation failed: %w", err)
 			}
 
-			currentAgent = newAgent
-			continue
-		}
+			// LLM completion
+			toolDefs := convertToolsToProviders(currentAgent.EffectiveTools())
+			_, llmSpan := tracing.Start(turnCtx, tracer, "llm.complete",
+				tracing.A("model", currentAgent.Model),
+				tracing.A("messages", len(messages)),
+				tracing.A("tools", len(toolDefs)))
+			logger.Debug("llm request", "turn", turn, "agent", currentAgent.Name,
+				"model", currentAgent.Model, "messages", len(messages), "tools", len(toolDefs))
 
-		// Handle tool calls, separating handoff tool calls from regular ones.
-		if len(completion.ToolCalls) > 0 {
-			var (
-				normalCalls []ToolCall
-				handoffs    []pendingHandoff
-			)
-			for _, call := range toolCallsFromProviders(completion.ToolCalls) {
-				if sub, mode, ok := currentAgent.HandoffForTool(call.Name); ok {
-					task, _ := call.Arguments["task"].(string)
-					handoffs = append(handoffs, pendingHandoff{call: call, sub: sub, mode: mode, task: task})
-					continue
+			completion, err := r.provider.Complete(turnCtx, currentAgent, messagesToProviders(messages), toolDefs)
+			if err != nil {
+				llmSpan.SetError(err)
+				llmSpan.End()
+				turnSpan.SetError(err)
+				logger.Error("llm request failed", "turn", turn, "error", err)
+				return fmt.Errorf("completion failed: %w", err)
+			}
+			llmSpan.SetAttributes(
+				tracing.A("tokens", completion.Usage.TotalTokens),
+				tracing.A("tool_calls", len(completion.ToolCalls)))
+			llmSpan.End()
+			logger.Debug("llm response", "turn", turn,
+				"tokens", completion.Usage.TotalTokens,
+				"tool_calls", len(completion.ToolCalls),
+				"content_chars", len(completion.Message.Content))
+
+			metrics.TotalTokens += completion.Usage.TotalTokens
+
+			// turnStart marks the history boundary before this assistant turn,
+			// used to fork a clean context for delegated subagents.
+			turnStart := len(messages)
+			messages = append(messages, messageFromProviders(completion.Message))
+
+			// Structured output -> done.
+			if currentAgent.OutputType != nil && completion.StructuredOutput != nil {
+				metrics.Duration = time.Since(startTime)
+				metrics.TotalTurns = turn + 1
+				result = &RunResult{FinalOutput: completion.StructuredOutput, Messages: messages, Agent: currentAgent, Metrics: metrics}
+				return nil
+			}
+
+			// Legacy provider-driven handoff (transfer of control).
+			if completion.Handoff != nil {
+				newAgent, ok := currentAgent.GetHandoff(completion.Handoff.TargetAgent)
+				if !ok {
+					return fmt.Errorf("handoff agent not found: %s", completion.Handoff.TargetAgent)
 				}
-				normalCalls = append(normalCalls, call)
-			}
-
-			if len(normalCalls) > 0 {
-				metrics.ToolCalls += len(normalCalls)
-				toolResponses, err := r.executeTools(ctx, currentAgent, normalCalls)
-				if err != nil {
-					return nil, fmt.Errorf("tool execution failed: %w", err)
-				}
-				for _, resp := range toolResponses {
-					messages = append(messages, toolMessage(resp.ToolCallID, toolContent(resp)))
-				}
-			}
-
-			// Only one handoff is acted on per turn; acknowledge any extras so
-			// their tool calls are still answered.
-			for i := 1; i < len(handoffs); i++ {
-				messages = append(messages, toolMessage(handoffs[i].call.ID,
-					"Ignored: only one handoff is processed per turn."))
-			}
-
-			if len(handoffs) > 0 {
-				h := handoffs[0]
 				metrics.Handoffs++
-
-				if h.mode == ContextShared {
-					messages = append(messages, toolMessage(h.call.ID,
-						fmt.Sprintf("Transferring to %s.", h.sub.Name)))
-					currentAgent = h.sub
-					continue
-				}
-
-				// ContextFresh / ContextForked: delegate and return the result.
-				nested := buildHandoffMessages(h.mode, messages[:turnStart], h.task)
-				subResult, err := r.executeLoop(ctx, h.sub, nested)
-				if err != nil {
-					return nil, fmt.Errorf("subagent %q failed: %w", h.sub.Name, err)
-				}
-				metrics.TotalTokens += subResult.Metrics.TotalTokens
-				metrics.ToolCalls += subResult.Metrics.ToolCalls
-				metrics.Handoffs += subResult.Metrics.Handoffs
-				messages = append(messages, toolMessage(h.call.ID,
-					fmt.Sprintf("%v", subResult.FinalOutput)))
+				logger.Info("handoff", "from", currentAgent.Name, "to", newAgent.Name, "mode", "shared")
+				nextAgent = newAgent
+				return nil
 			}
 
-			continue
+			// Tool calls, separating handoff tool calls from regular ones.
+			if len(completion.ToolCalls) > 0 {
+				var (
+					normalCalls []ToolCall
+					handoffList []pendingHandoff
+				)
+				for _, call := range toolCallsFromProviders(completion.ToolCalls) {
+					if sub, mode, ok := currentAgent.HandoffForTool(call.Name); ok {
+						task, _ := call.Arguments["task"].(string)
+						handoffList = append(handoffList, pendingHandoff{call: call, sub: sub, mode: mode, task: task})
+						continue
+					}
+					normalCalls = append(normalCalls, call)
+				}
+
+				if len(normalCalls) > 0 {
+					metrics.ToolCalls += len(normalCalls)
+					toolResponses, err := r.executeTools(turnCtx, tracer, logger, currentAgent, normalCalls)
+					if err != nil {
+						turnSpan.SetError(err)
+						return fmt.Errorf("tool execution failed: %w", err)
+					}
+					for _, resp := range toolResponses {
+						messages = append(messages, toolMessage(resp.ToolCallID, toolContent(resp)))
+					}
+				}
+
+				// Only one handoff is acted on per turn; acknowledge extras.
+				for i := 1; i < len(handoffList); i++ {
+					messages = append(messages, toolMessage(handoffList[i].call.ID,
+						"Ignored: only one handoff is processed per turn."))
+				}
+
+				if len(handoffList) > 0 {
+					h := handoffList[0]
+					metrics.Handoffs++
+
+					if h.mode == ContextShared {
+						logger.Info("handoff", "from", currentAgent.Name, "to", h.sub.Name, "mode", "shared")
+						messages = append(messages, toolMessage(h.call.ID,
+							fmt.Sprintf("Transferring to %s.", h.sub.Name)))
+						nextAgent = h.sub
+						return nil
+					}
+
+					// ContextFresh / ContextForked: delegate and return the result.
+					delegateCtx, hSpan := tracing.Start(turnCtx, tracer, "handoff.delegate",
+						tracing.A("to", h.sub.Name), tracing.A("mode", h.mode.String()), tracing.A("task", h.task))
+					logger.Info("delegate", "from", currentAgent.Name, "to", h.sub.Name, "mode", h.mode.String())
+
+					nested := buildHandoffMessages(h.mode, messages[:turnStart], h.task)
+					subCtx := *ctx
+					subCtx.Context = delegateCtx
+					subResult, err := r.executeLoop(&subCtx, tracer, logger.With("parent", currentAgent.Name), h.sub, nested)
+					if err != nil {
+						hSpan.SetError(err)
+						hSpan.End()
+						return fmt.Errorf("subagent %q failed: %w", h.sub.Name, err)
+					}
+					hSpan.SetAttributes(tracing.A("tokens", subResult.Metrics.TotalTokens))
+					hSpan.End()
+					metrics.TotalTokens += subResult.Metrics.TotalTokens
+					metrics.ToolCalls += subResult.Metrics.ToolCalls
+					metrics.Handoffs += subResult.Metrics.Handoffs
+					messages = append(messages, toolMessage(h.call.ID,
+						fmt.Sprintf("%v", subResult.FinalOutput)))
+				}
+				return nil // continue to next turn
+			}
+
+			// Plain text final output.
+			if currentAgent.OutputType == nil {
+				metrics.Duration = time.Since(startTime)
+				metrics.TotalTurns = turn + 1
+				result = &RunResult{FinalOutput: completion.Message.Content, Messages: messages, Agent: currentAgent, Metrics: metrics}
+			}
+			return nil
+		}()
+
+		if turnErr != nil {
+			return nil, turnErr
 		}
-
-		// If no tools, handoffs, or structured output, we have final output
-		if currentAgent.OutputType == nil {
-			metrics.Duration = time.Since(startTime)
-			metrics.TotalTurns = turn + 1
-
-			return &RunResult{
-				FinalOutput: completion.Message.Content,
-				Messages:    messages,
-				Agent:       currentAgent,
-				Metrics:     metrics,
-			}, nil
+		if result != nil {
+			return result, nil
+		}
+		if nextAgent != nil {
+			currentAgent = nextAgent
 		}
 	}
 
 	return nil, ErrMaxTurnsExceeded
 }
 
-// executeTools runs tool calls in parallel or sequence
-func (r *Runner) executeTools(ctx *RunContext, agent *Agent, toolCalls []ToolCall) ([]ToolResponse, error) {
+// executeTools runs tool calls in parallel or sequence, tracing and logging each.
+func (r *Runner) executeTools(ctx context.Context, tracer tracing.Tracer, logger *slog.Logger, agent *Agent, toolCalls []ToolCall) ([]ToolResponse, error) {
 	responses := make([]ToolResponse, len(toolCalls))
 
 	if r.parallelTools && len(toolCalls) > 1 {
-		// Execute tools in parallel
-		g, gCtx := errgroup.WithContext(ctx.Context)
-
+		g, gCtx := errgroup.WithContext(ctx)
 		for i, call := range toolCalls {
 			i, call := i, call // capture loop variables
-
 			g.Go(func() error {
-				tool := r.findTool(agent, call.Name)
-				if tool == nil {
-					responses[i] = ToolResponse{
-						ToolCallID: call.ID,
-						Error:      fmt.Errorf("tool not found: %s", call.Name),
-					}
-					return nil
-				}
-
-				result, err := tool.Execute(gCtx, call.Arguments)
-				responses[i] = ToolResponse{
-					ToolCallID: call.ID,
-					Content:    result,
-					Error:      err,
-				}
+				responses[i] = r.runTool(gCtx, tracer, logger, agent, call)
 				return nil
 			})
 		}
-
 		if err := g.Wait(); err != nil {
 			return nil, err
 		}
 	} else {
-		// Execute tools sequentially
 		for i, call := range toolCalls {
-			tool := r.findTool(agent, call.Name)
-			if tool == nil {
-				responses[i] = ToolResponse{
-					ToolCallID: call.ID,
-					Error:      fmt.Errorf("tool not found: %s", call.Name),
-				}
-				continue
-			}
-
-			result, err := tool.Execute(ctx.Context, call.Arguments)
-			responses[i] = ToolResponse{
-				ToolCallID: call.ID,
-				Content:    result,
-				Error:      err,
-			}
+			responses[i] = r.runTool(ctx, tracer, logger, agent, call)
 		}
 	}
 
 	return responses, nil
+}
+
+// runTool executes a single tool call within its own span.
+func (r *Runner) runTool(ctx context.Context, tracer tracing.Tracer, logger *slog.Logger, agent *Agent, call ToolCall) ToolResponse {
+	ctx, span := tracing.Start(ctx, tracer, "tool.execute",
+		tracing.A("tool", call.Name),
+		tracing.A("args", argsPreview(call.Arguments)))
+	defer span.End()
+
+	tool := r.findTool(agent, call.Name)
+	if tool == nil {
+		err := fmt.Errorf("tool not found: %s", call.Name)
+		span.SetError(err)
+		logger.Warn("tool not found", "tool", call.Name)
+		return ToolResponse{ToolCallID: call.ID, Error: err}
+	}
+
+	start := time.Now()
+	logger.Debug("tool call", "tool", call.Name)
+	result, err := tool.Execute(ctx, call.Arguments)
+	if err != nil {
+		span.SetError(err)
+		logger.Error("tool failed", "tool", call.Name, "error", err, "duration", time.Since(start))
+		return ToolResponse{ToolCallID: call.ID, Error: err}
+	}
+
+	resultStr := fmt.Sprintf("%v", result)
+	span.SetAttributes(tracing.A("result_chars", len(resultStr)))
+	logger.Debug("tool result", "tool", call.Name, "duration", time.Since(start), "result_chars", len(resultStr))
+	return ToolResponse{ToolCallID: call.ID, Content: result}
+}
+
+// argsPreview renders tool arguments compactly for trace attributes.
+func argsPreview(args map[string]interface{}) string {
+	b, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Sprintf("%v", args)
+	}
+	return string(b)
 }
 
 // findTool locates a tool by name, including builtins such as load_skill.
@@ -323,20 +416,24 @@ func (r *Runner) findTool(agent *Agent, name string) tools.Tool {
 	return nil
 }
 
-// validateGuardrails runs all guardrail checks
-func (r *Runner) validateGuardrails(agent *Agent, messages []Message) error {
+// validateGuardrails runs all guardrail checks for the latest message.
+func (r *Runner) validateGuardrails(ctx context.Context, tracer tracing.Tracer, logger *slog.Logger, agent *Agent, messages []Message) error {
 	if len(messages) == 0 || len(agent.Guardrails) == 0 {
 		return nil
 	}
 
-	lastMessage := messages[len(messages)-1]
+	_, span := tracing.Start(ctx, tracer, "guardrails", tracing.A("count", len(agent.Guardrails)))
+	defer span.End()
 
+	lastMessage := messages[len(messages)-1]
 	for _, guardrail := range agent.Guardrails {
 		if err := guardrail.Validate(lastMessage.Content); err != nil {
-			return fmt.Errorf("guardrail %T failed: %w", guardrail, err)
+			span.SetError(err)
+			logger.Warn("guardrail blocked", "guardrail", guardrail.Name(), "error", err)
+			return fmt.Errorf("guardrail %s failed: %w", guardrail.Name(), err)
 		}
 	}
-
+	logger.Debug("guardrails passed", "count", len(agent.Guardrails))
 	return nil
 }
 

--- a/pkg/agents/runner.go
+++ b/pkg/agents/runner.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -12,7 +13,6 @@ import (
 	"github.com/ryanhill4L/agents-sdk/pkg/providers"
 	"github.com/ryanhill4L/agents-sdk/pkg/tools"
 	"github.com/ryanhill4L/agents-sdk/pkg/tracing"
-	"golang.org/x/sync/errgroup"
 )
 
 // Runner executes agent workflows
@@ -266,12 +266,7 @@ func (r *Runner) executeLoop(ctx *RunContext, tracer tracing.Tracer, logger *slo
 
 				if len(normalCalls) > 0 {
 					metrics.ToolCalls += len(normalCalls)
-					toolResponses, err := r.executeTools(turnCtx, tracer, logger, currentAgent, normalCalls)
-					if err != nil {
-						turnSpan.SetError(err)
-						return fmt.Errorf("tool execution failed: %w", err)
-					}
-					for _, resp := range toolResponses {
+					for _, resp := range r.executeTools(turnCtx, tracer, logger, currentAgent, normalCalls) {
 						messages = append(messages, toolMessage(resp.ToolCallID, toolContent(resp)))
 					}
 				}
@@ -342,29 +337,30 @@ func (r *Runner) executeLoop(ctx *RunContext, tracer tracing.Tracer, logger *slo
 	return nil, ErrMaxTurnsExceeded
 }
 
-// executeTools runs tool calls in parallel or sequence, tracing and logging each.
-func (r *Runner) executeTools(ctx context.Context, tracer tracing.Tracer, logger *slog.Logger, agent *Agent, toolCalls []ToolCall) ([]ToolResponse, error) {
+// executeTools runs tool calls in parallel or sequence, tracing and logging
+// each. Per-tool failures are reported in the corresponding ToolResponse.Error
+// (and fed back to the model), so this never fails as a whole.
+func (r *Runner) executeTools(ctx context.Context, tracer tracing.Tracer, logger *slog.Logger, agent *Agent, toolCalls []ToolCall) []ToolResponse {
 	responses := make([]ToolResponse, len(toolCalls))
 
 	if r.parallelTools && len(toolCalls) > 1 {
-		g, gCtx := errgroup.WithContext(ctx)
+		var wg sync.WaitGroup
 		for i, call := range toolCalls {
 			i, call := i, call // capture loop variables
-			g.Go(func() error {
-				responses[i] = r.runTool(gCtx, tracer, logger, agent, call)
-				return nil
-			})
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				responses[i] = r.runTool(ctx, tracer, logger, agent, call)
+			}()
 		}
-		if err := g.Wait(); err != nil {
-			return nil, err
-		}
+		wg.Wait()
 	} else {
 		for i, call := range toolCalls {
 			responses[i] = r.runTool(ctx, tracer, logger, agent, call)
 		}
 	}
 
-	return responses, nil
+	return responses
 }
 
 // runTool executes a single tool call within its own span.
@@ -555,24 +551,24 @@ func convertProperties(props map[string]tools.PropertySchema) map[string]provide
 	return result
 }
 
-// RunAsync provides a channel-based async interface
-func RunAsync(ctx context.Context, agent *Agent, input string, opts ...RunnerOption) <-chan *RunResult {
-	resultChan := make(chan *RunResult, 1)
+// AsyncResult carries the outcome of a RunAsync call, including any error.
+type AsyncResult struct {
+	Result *RunResult
+	Err    error
+}
+
+// RunAsync provides a channel-based async interface. The sent AsyncResult
+// carries either a Result or an Err, so callers can distinguish failure from a
+// successful run rather than string-sniffing the output.
+func RunAsync(ctx context.Context, agent *Agent, input string, opts ...RunnerOption) <-chan AsyncResult {
+	resultChan := make(chan AsyncResult, 1)
 
 	go func() {
 		defer close(resultChan)
 
 		runner := NewRunner(opts...)
 		result, err := runner.Run(ctx, agent, input)
-
-		if err != nil {
-			// Include error in result
-			result = &RunResult{
-				FinalOutput: fmt.Sprintf("Error: %v", err),
-			}
-		}
-
-		resultChan <- result
+		resultChan <- AsyncResult{Result: result, Err: err}
 	}()
 
 	return resultChan

--- a/pkg/agents/runner.go
+++ b/pkg/agents/runner.go
@@ -139,7 +139,7 @@ func (r *Runner) executeLoop(ctx *RunContext, agent *Agent, messages []Message) 
 		}
 
 		// Get LLM completion
-		toolDefs := convertToolsToProviders(currentAgent.Tools)
+		toolDefs := convertToolsToProviders(currentAgent.EffectiveTools())
 		completion, err := r.provider.Complete(ctx.Context, currentAgent, messagesToProviders(messages), toolDefs)
 		if err != nil {
 			return nil, fmt.Errorf("completion failed: %w", err)
@@ -273,9 +273,9 @@ func (r *Runner) executeTools(ctx *RunContext, agent *Agent, toolCalls []ToolCal
 	return responses, nil
 }
 
-// findTool locates a tool by name
+// findTool locates a tool by name, including builtins such as load_skill.
 func (r *Runner) findTool(agent *Agent, name string) tools.Tool {
-	for _, tool := range agent.Tools {
+	for _, tool := range agent.EffectiveTools() {
 		if tool.Name() == name {
 			return tool
 		}

--- a/pkg/agents/skills_test.go
+++ b/pkg/agents/skills_test.go
@@ -1,0 +1,51 @@
+package agents
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/skills"
+)
+
+func TestGetInstructionsIncludesSkillCatalog(t *testing.T) {
+	agent := NewAgent("a",
+		WithInstructions("Base instructions."),
+		WithSkills(skills.Skill{Name: "refunds", Description: "Refund flow"}),
+	)
+
+	got := agent.GetInstructions()
+	if !strings.Contains(got, "Base instructions.") {
+		t.Error("expected base instructions to be present")
+	}
+	if !strings.Contains(got, "refunds") {
+		t.Errorf("expected skill catalog in instructions, got:\n%s", got)
+	}
+}
+
+func TestGetInstructionsNoSkills(t *testing.T) {
+	agent := NewAgent("a", WithInstructions("Just this."))
+	if agent.GetInstructions() != "Just this." {
+		t.Errorf("instructions = %q", agent.GetInstructions())
+	}
+}
+
+func TestEffectiveToolsAddsLoadSkill(t *testing.T) {
+	agent := NewAgent("a", WithSkills(skills.Skill{Name: "x", Description: "d", Content: "c"}))
+
+	tools := agent.EffectiveTools()
+	var found bool
+	for _, tl := range tools {
+		if tl.Name() == skills.LoadSkillToolName {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected load_skill tool in EffectiveTools")
+	}
+
+	// Without skills, no builtin is added.
+	plain := NewAgent("b")
+	if len(plain.EffectiveTools()) != 0 {
+		t.Errorf("expected no tools, got %d", len(plain.EffectiveTools()))
+	}
+}

--- a/pkg/agents/tracing_test.go
+++ b/pkg/agents/tracing_test.go
@@ -1,0 +1,105 @@
+package agents
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/providers"
+	"github.com/ryanhill4L/agents-sdk/pkg/tools"
+	"github.com/ryanhill4L/agents-sdk/pkg/tracing"
+)
+
+// toolThenText calls a named tool on the first turn, then returns final text.
+type toolThenText struct {
+	mu       sync.Mutex
+	calls    int
+	toolName string
+}
+
+func (p *toolThenText) Complete(_ context.Context, _ providers.Agent, _ []providers.Message, _ []providers.ToolDefinition) (*providers.Completion, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := p.calls
+	p.calls++
+	if n == 0 {
+		return &providers.Completion{
+			Message:   providers.Message{Role: "assistant"},
+			ToolCalls: []providers.ToolCall{{ID: "c1", Name: p.toolName, Arguments: map[string]interface{}{}}},
+			Usage:     providers.Usage{TotalTokens: 7},
+		}, nil
+	}
+	return &providers.Completion{Message: providers.Message{Role: "assistant", Content: "done"}}, nil
+}
+
+func spanNames(records []tracing.SpanRecord) map[string]int {
+	counts := map[string]int{}
+	for _, r := range records {
+		counts[r.Name]++
+	}
+	return counts
+}
+
+func TestRunRecordsTraceTree(t *testing.T) {
+	pingTool := tools.NewTool("ping", "pings", func(_ context.Context, _ map[string]interface{}) (interface{}, error) {
+		return "pong", nil
+	})
+	agent := NewAgent("traced", WithTools(pingTool))
+
+	result, err := NewRunner(WithProvider(&toolThenText{toolName: "ping"})).Run(context.Background(), agent, "go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	counts := spanNames(result.Traces)
+	for _, name := range []string{"agent.run", "turn", "llm.complete", "tool.execute"} {
+		if counts[name] == 0 {
+			t.Errorf("expected a %q span, traces=%v", name, counts)
+		}
+	}
+
+	// The root run span is at depth 0; tool.execute carries the tool attribute.
+	var sawRootDepth0, sawToolAttr bool
+	for _, r := range result.Traces {
+		if r.Name == "agent.run" && r.Depth == 0 {
+			sawRootDepth0 = true
+		}
+		if r.Name == "tool.execute" {
+			for _, a := range r.Attributes {
+				if a.Key == "tool" && a.Value == "ping" {
+					sawToolAttr = true
+				}
+			}
+		}
+	}
+	if !sawRootDepth0 {
+		t.Error("expected agent.run at depth 0")
+	}
+	if !sawToolAttr {
+		t.Error("expected tool.execute span with tool=ping attribute")
+	}
+}
+
+func TestRunWithLoggerEmitsRecords(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	agent := NewAgent("logged")
+	_, err := NewRunner(
+		WithProvider(&toolThenText{toolName: "none"}), // no such tool; returns text on turn 2
+		WithLogger(logger),
+	).Run(context.Background(), agent, "hello")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	out := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte("run started")) {
+		t.Errorf("expected 'run started' log, got: %s", out)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("run completed")) {
+		t.Errorf("expected 'run completed' log, got: %s", out)
+	}
+}

--- a/pkg/channels/channel.go
+++ b/pkg/channels/channel.go
@@ -1,0 +1,16 @@
+// Package channels provides integration adapters that connect an agent to the
+// outside world. Each channel turns inbound messages into agent runs and routes
+// the output back. The HTTP channel is the default, powering `eve dev`.
+package channels
+
+import "context"
+
+// Handler runs an agent for a single inbound message and returns its reply.
+type Handler func(ctx context.Context, input string) (string, error)
+
+// Channel is an integration adapter. Start blocks until ctx is cancelled or an
+// unrecoverable error occurs.
+type Channel interface {
+	Name() string
+	Start(ctx context.Context, handler Handler) error
+}

--- a/pkg/channels/http.go
+++ b/pkg/channels/http.go
@@ -1,0 +1,97 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+)
+
+// HTTPChannel exposes an agent over HTTP. POST /chat with a JSON body
+// {"input": "..."} returns {"output": "..."}. GET /health returns 200.
+type HTTPChannel struct {
+	// Addr is the listen address, e.g. ":8080".
+	Addr string
+}
+
+// NewHTTPChannel creates an HTTP channel bound to addr (defaults to ":8080").
+func NewHTTPChannel(addr string) *HTTPChannel {
+	if addr == "" {
+		addr = ":8080"
+	}
+	return &HTTPChannel{Addr: addr}
+}
+
+// Name identifies the channel.
+func (c *HTTPChannel) Name() string { return "http" }
+
+type chatRequest struct {
+	Input string `json:"input"`
+}
+
+type chatResponse struct {
+	Output string `json:"output,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// Start runs the HTTP server until ctx is cancelled.
+func (c *HTTPChannel) Start(ctx context.Context, handler Handler) error {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	mux.HandleFunc("/chat", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, chatResponse{Error: "use POST"})
+			return
+		}
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, chatResponse{Error: "invalid JSON body"})
+			return
+		}
+		if req.Input == "" {
+			writeJSON(w, http.StatusBadRequest, chatResponse{Error: "'input' is required"})
+			return
+		}
+
+		output, err := handler(r.Context(), req.Input)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, chatResponse{Error: err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, chatResponse{Output: output})
+	})
+
+	server := &http.Server{
+		Addr:              c.Addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return server.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -12,7 +12,9 @@
 package loader
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -44,16 +46,42 @@ type Config struct {
 	MaxTokens   int      `yaml:"max_tokens"`
 	TopP        *float32 `yaml:"top_p"`
 	Tools       []string `yaml:"tools"`
+
+	// Subagents maps a subagent directory/name to its handoff context mode
+	// (shared | fresh | forked). Omitted subagents default to shared.
+	Subagents map[string]string `yaml:"subagents"`
+
+	// Skills declares remote skills fetched at load time. Local skills in the
+	// skills/ directory are always loaded in addition to these.
+	Skills []skills.RemoteSource `yaml:"skills"`
+}
+
+// Options configures loading, primarily for fetching remote skills.
+type Options struct {
+	// Context for remote fetches (defaults to context.Background()).
+	Context context.Context
+	// SkillCache is where remote skills are cached (empty uses the OS cache dir).
+	SkillCache string
+	// AllowedHosts restricts remote skill hosts (empty uses the safe default).
+	AllowedHosts []string
+	// HTTPClient overrides the HTTP client used for remote fetches.
+	HTTPClient *http.Client
 }
 
 // Load builds an agent (and its subagents, recursively) from dir. Tools named in
 // agent.yaml are resolved against registry; pass a nil registry only if no agent
 // in the tree declares tools.
 func Load(dir string, registry *tools.Registry) (*agents.Agent, error) {
-	return load(dir, registry, map[string]bool{})
+	return LoadWithOptions(dir, registry, Options{})
 }
 
-func load(dir string, registry *tools.Registry, seen map[string]bool) (*agents.Agent, error) {
+// LoadWithOptions is Load with explicit options (e.g. a skill cache directory or
+// host allowlist for remote skills).
+func LoadWithOptions(dir string, registry *tools.Registry, opts Options) (*agents.Agent, error) {
+	return load(dir, registry, opts, map[string]bool{})
+}
+
+func load(dir string, registry *tools.Registry, opts Options, seen map[string]bool) (*agents.Agent, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
@@ -82,26 +110,26 @@ func load(dir string, registry *tools.Registry, seen map[string]bool) (*agents.A
 		name = filepath.Base(abs)
 	}
 
-	opts := []agents.AgentOption{}
+	agentOpts := []agents.AgentOption{}
 
 	instructions, err := readInstructions(filepath.Join(abs, InstructionsFile))
 	if err != nil {
 		return nil, err
 	}
 	if instructions != "" {
-		opts = append(opts, agents.WithInstructions(instructions))
+		agentOpts = append(agentOpts, agents.WithInstructions(instructions))
 	}
 	if cfg.Model != "" {
-		opts = append(opts, agents.WithModel(cfg.Model))
+		agentOpts = append(agentOpts, agents.WithModel(cfg.Model))
 	}
 	if cfg.Provider != "" {
-		opts = append(opts, agents.WithProviderName(cfg.Provider))
+		agentOpts = append(agentOpts, agents.WithProviderName(cfg.Provider))
 	}
 	if cfg.Temperature != nil {
-		opts = append(opts, agents.WithTemperature(*cfg.Temperature))
+		agentOpts = append(agentOpts, agents.WithTemperature(*cfg.Temperature))
 	}
 	if cfg.MaxTokens > 0 {
-		opts = append(opts, agents.WithMaxTokens(cfg.MaxTokens))
+		agentOpts = append(agentOpts, agents.WithMaxTokens(cfg.MaxTokens))
 	}
 
 	// Resolve declared tools.
@@ -113,28 +141,47 @@ func load(dir string, registry *tools.Registry, seen map[string]bool) (*agents.A
 		if err != nil {
 			return nil, fmt.Errorf("agent %q: %w", name, err)
 		}
-		opts = append(opts, agents.WithTools(resolved...))
+		agentOpts = append(agentOpts, agents.WithTools(resolved...))
 	}
 
-	// Load skills.
+	// Load local skills, then any declared remote skills.
 	loadedSkills, err := skills.LoadDir(filepath.Join(abs, SkillsDir))
 	if err != nil {
 		return nil, fmt.Errorf("agent %q: loading skills: %w", name, err)
 	}
+	if len(cfg.Skills) > 0 {
+		fetchOpts := skills.FetchOptions{
+			CacheDir:     opts.SkillCache,
+			AllowedHosts: opts.AllowedHosts,
+			Client:       opts.HTTPClient,
+		}
+		remote, err := skills.FetchAll(opts.Context, cfg.Skills, fetchOpts)
+		if err != nil {
+			return nil, fmt.Errorf("agent %q: fetching remote skills: %w", name, err)
+		}
+		loadedSkills = append(loadedSkills, remote...)
+	}
+	if err := assertUniqueSkillNames(loadedSkills); err != nil {
+		return nil, fmt.Errorf("agent %q: %w", name, err)
+	}
 	if len(loadedSkills) > 0 {
-		opts = append(opts, agents.WithSkills(loadedSkills...))
+		agentOpts = append(agentOpts, agents.WithSkills(loadedSkills...))
 	}
 
 	// Load subagents as handoffs.
-	subagents, err := loadSubagents(filepath.Join(abs, SubagentsDir), registry, seen)
+	subagents, err := loadSubagents(filepath.Join(abs, SubagentsDir), registry, opts, seen)
 	if err != nil {
 		return nil, fmt.Errorf("agent %q: %w", name, err)
 	}
-	if len(subagents) > 0 {
-		opts = append(opts, agents.WithHandoffs(subagents...))
+	for _, sub := range subagents {
+		mode, err := agents.ParseHandoffMode(cfg.Subagents[sub.Name])
+		if err != nil {
+			return nil, fmt.Errorf("agent %q: subagent %q: %w", name, sub.Name, err)
+		}
+		agentOpts = append(agentOpts, agents.WithHandoff(sub, mode))
 	}
 
-	agent := agents.NewAgent(name, opts...)
+	agent := agents.NewAgent(name, agentOpts...)
 	agent.Dir = abs
 
 	if err := agent.Validate(); err != nil {
@@ -143,7 +190,7 @@ func load(dir string, registry *tools.Registry, seen map[string]bool) (*agents.A
 	return agent, nil
 }
 
-func loadSubagents(dir string, registry *tools.Registry, seen map[string]bool) ([]*agents.Agent, error) {
+func loadSubagents(dir string, registry *tools.Registry, opts Options, seen map[string]bool) ([]*agents.Agent, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -157,7 +204,7 @@ func loadSubagents(dir string, registry *tools.Registry, seen map[string]bool) (
 		if !entry.IsDir() {
 			continue
 		}
-		sub, err := load(filepath.Join(dir, entry.Name()), registry, seen)
+		sub, err := load(filepath.Join(dir, entry.Name()), registry, opts, seen)
 		if err != nil {
 			return nil, err
 		}
@@ -165,6 +212,18 @@ func loadSubagents(dir string, registry *tools.Registry, seen map[string]bool) (
 	}
 	sort.Slice(subs, func(i, j int) bool { return subs[i].Name < subs[j].Name })
 	return subs, nil
+}
+
+// assertUniqueSkillNames guards against two skills (local or remote) colliding.
+func assertUniqueSkillNames(loaded []skills.Skill) error {
+	seen := make(map[string]bool, len(loaded))
+	for _, s := range loaded {
+		if seen[s.Name] {
+			return fmt.Errorf("duplicate skill name %q", s.Name)
+		}
+		seen[s.Name] = true
+	}
+	return nil
 }
 
 func readConfig(path string) (Config, error) {

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/ryanhill4L/agents-sdk/pkg/agents"
+	"github.com/ryanhill4L/agents-sdk/pkg/mcp"
 	"github.com/ryanhill4L/agents-sdk/pkg/skills"
 	"github.com/ryanhill4L/agents-sdk/pkg/tools"
 )
@@ -54,6 +55,10 @@ type Config struct {
 	// Skills declares remote skills fetched at load time. Local skills in the
 	// skills/ directory are always loaded in addition to these.
 	Skills []skills.RemoteSource `yaml:"skills"`
+
+	// MCP declares Model Context Protocol servers whose tools are connected at
+	// load time and added to the agent.
+	MCP []mcp.ServerConfig `yaml:"mcp"`
 }
 
 // Options configures loading, primarily for fetching remote skills.
@@ -66,6 +71,9 @@ type Options struct {
 	AllowedHosts []string
 	// HTTPClient overrides the HTTP client used for remote fetches.
 	HTTPClient *http.Client
+	// SkipMCP, when true, records declared MCP servers without connecting to
+	// them (used by `eve validate` to stay offline).
+	SkipMCP bool
 }
 
 // Load builds an agent (and its subagents, recursively) from dir. Tools named in
@@ -181,8 +189,31 @@ func load(dir string, registry *tools.Registry, opts Options, seen map[string]bo
 		agentOpts = append(agentOpts, agents.WithHandoff(sub, mode))
 	}
 
+	// Connect declared MCP servers and add their tools.
+	var mcpManager *mcp.Manager
+	var mcpServers []string
+	for _, s := range cfg.MCP {
+		mcpServers = append(mcpServers, s.Name)
+	}
+	if len(cfg.MCP) > 0 && !opts.SkipMCP {
+		ctx := opts.Context
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		mgr, err := mcp.ConnectAll(ctx, cfg.MCP)
+		if err != nil {
+			return nil, fmt.Errorf("agent %q: %w", name, err)
+		}
+		mcpManager = mgr
+		agentOpts = append(agentOpts, agents.WithTools(mgr.Tools()...))
+	}
+
 	agent := agents.NewAgent(name, agentOpts...)
 	agent.Dir = abs
+	agent.MCPServers = mcpServers
+	if mcpManager != nil {
+		agent.AddCloser(mcpManager)
+	}
 
 	if err := agent.Validate(); err != nil {
 		return nil, fmt.Errorf("agent %q: %w", name, err)

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -1,0 +1,194 @@
+// Package loader builds agents from the filesystem. An agent is a directory:
+//
+//	myagent/
+//	  agent.yaml         # model / provider / temperature / tools
+//	  instructions.md    # system prompt
+//	  skills/*.md        # on-demand knowledge
+//	  subagents/<name>/  # delegated agents (handoffs), same layout recursively
+//
+// This mirrors Eve's "the filesystem is the authoring interface" idea, adapted
+// to Go: because tools are compiled functions, agent.yaml references them by
+// name and the loader resolves them against a tools.Registry.
+package loader
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/agents"
+	"github.com/ryanhill4L/agents-sdk/pkg/skills"
+	"github.com/ryanhill4L/agents-sdk/pkg/tools"
+)
+
+// Standard filenames and subdirectories within an agent directory.
+const (
+	ConfigFile       = "agent.yaml"
+	InstructionsFile = "instructions.md"
+	SkillsDir        = "skills"
+	SubagentsDir     = "subagents"
+	SchedulesDir     = "schedules"
+	ChannelsDir      = "channels"
+)
+
+// Config is the declarative agent.yaml schema.
+type Config struct {
+	Name        string   `yaml:"name"`
+	Model       string   `yaml:"model"`
+	Provider    string   `yaml:"provider"`
+	Temperature *float32 `yaml:"temperature"`
+	MaxTokens   int      `yaml:"max_tokens"`
+	TopP        *float32 `yaml:"top_p"`
+	Tools       []string `yaml:"tools"`
+}
+
+// Load builds an agent (and its subagents, recursively) from dir. Tools named in
+// agent.yaml are resolved against registry; pass a nil registry only if no agent
+// in the tree declares tools.
+func Load(dir string, registry *tools.Registry) (*agents.Agent, error) {
+	return load(dir, registry, map[string]bool{})
+}
+
+func load(dir string, registry *tools.Registry, seen map[string]bool) (*agents.Agent, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	if seen[abs] {
+		return nil, fmt.Errorf("circular subagent reference at %s", abs)
+	}
+	seen[abs] = true
+	defer delete(seen, abs)
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("agent directory %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", dir)
+	}
+
+	cfg, err := readConfig(filepath.Join(abs, ConfigFile))
+	if err != nil {
+		return nil, err
+	}
+
+	name := cfg.Name
+	if name == "" {
+		name = filepath.Base(abs)
+	}
+
+	opts := []agents.AgentOption{}
+
+	instructions, err := readInstructions(filepath.Join(abs, InstructionsFile))
+	if err != nil {
+		return nil, err
+	}
+	if instructions != "" {
+		opts = append(opts, agents.WithInstructions(instructions))
+	}
+	if cfg.Model != "" {
+		opts = append(opts, agents.WithModel(cfg.Model))
+	}
+	if cfg.Provider != "" {
+		opts = append(opts, agents.WithProviderName(cfg.Provider))
+	}
+	if cfg.Temperature != nil {
+		opts = append(opts, agents.WithTemperature(*cfg.Temperature))
+	}
+	if cfg.MaxTokens > 0 {
+		opts = append(opts, agents.WithMaxTokens(cfg.MaxTokens))
+	}
+
+	// Resolve declared tools.
+	if len(cfg.Tools) > 0 {
+		if registry == nil {
+			return nil, fmt.Errorf("agent %q declares tools %v but no tool registry was provided", name, cfg.Tools)
+		}
+		resolved, err := registry.Resolve(cfg.Tools)
+		if err != nil {
+			return nil, fmt.Errorf("agent %q: %w", name, err)
+		}
+		opts = append(opts, agents.WithTools(resolved...))
+	}
+
+	// Load skills.
+	loadedSkills, err := skills.LoadDir(filepath.Join(abs, SkillsDir))
+	if err != nil {
+		return nil, fmt.Errorf("agent %q: loading skills: %w", name, err)
+	}
+	if len(loadedSkills) > 0 {
+		opts = append(opts, agents.WithSkills(loadedSkills...))
+	}
+
+	// Load subagents as handoffs.
+	subagents, err := loadSubagents(filepath.Join(abs, SubagentsDir), registry, seen)
+	if err != nil {
+		return nil, fmt.Errorf("agent %q: %w", name, err)
+	}
+	if len(subagents) > 0 {
+		opts = append(opts, agents.WithHandoffs(subagents...))
+	}
+
+	agent := agents.NewAgent(name, opts...)
+	agent.Dir = abs
+
+	if err := agent.Validate(); err != nil {
+		return nil, fmt.Errorf("agent %q: %w", name, err)
+	}
+	return agent, nil
+}
+
+func loadSubagents(dir string, registry *tools.Registry, seen map[string]bool) ([]*agents.Agent, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var subs []*agents.Agent
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sub, err := load(filepath.Join(dir, entry.Name()), registry, seen)
+		if err != nil {
+			return nil, err
+		}
+		subs = append(subs, sub)
+	}
+	sort.Slice(subs, func(i, j int) bool { return subs[i].Name < subs[j].Name })
+	return subs, nil
+}
+
+func readConfig(path string) (Config, error) {
+	var cfg Config
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, fmt.Errorf("missing %s", ConfigFile)
+		}
+		return cfg, err
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("invalid %s: %w", ConfigFile, err)
+	}
+	return cfg, nil
+}
+
+func readInstructions(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -14,6 +14,7 @@ package loader
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -26,6 +27,7 @@ import (
 	"github.com/ryanhill4L/agents-sdk/pkg/mcp"
 	"github.com/ryanhill4L/agents-sdk/pkg/skills"
 	"github.com/ryanhill4L/agents-sdk/pkg/tools"
+	"github.com/ryanhill4L/agents-sdk/pkg/tracing"
 )
 
 // Standard filenames and subdirectories within an agent directory.
@@ -74,6 +76,8 @@ type Options struct {
 	// SkipMCP, when true, records declared MCP servers without connecting to
 	// them (used by `eve validate` to stay offline).
 	SkipMCP bool
+	// Logger receives structured load-time logs (nil disables logging).
+	Logger *slog.Logger
 }
 
 // Load builds an agent (and its subagents, recursively) from dir. Tools named in
@@ -117,6 +121,9 @@ func load(dir string, registry *tools.Registry, opts Options, seen map[string]bo
 	if name == "" {
 		name = filepath.Base(abs)
 	}
+
+	log := tracing.OrDiscard(opts.Logger)
+	log.Debug("loading agent", "name", name, "dir", abs)
 
 	agentOpts := []agents.AgentOption{}
 
@@ -200,7 +207,9 @@ func load(dir string, registry *tools.Registry, opts Options, seen map[string]bo
 		if ctx == nil {
 			ctx = context.Background()
 		}
-		mgr, err := mcp.ConnectAll(ctx, cfg.MCP)
+		logger := tracing.OrDiscard(opts.Logger)
+		logger.Info("connecting mcp servers", "agent", name, "count", len(cfg.MCP))
+		mgr, err := mcp.ConnectAll(ctx, cfg.MCP, opts.Logger)
 		if err != nil {
 			return nil, fmt.Errorf("agent %q: %w", name, err)
 		}

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -2,10 +2,15 @@ package loader
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/ryanhill4L/agents-sdk/pkg/agents"
 	"github.com/ryanhill4L/agents-sdk/pkg/tools"
 )
 
@@ -82,6 +87,57 @@ tools:
 	}
 	if !hasLoadSkill {
 		t.Error("expected load_skill builtin in EffectiveTools")
+	}
+}
+
+func TestLoadSubagentModes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ConfigFile), `name: parent
+model: m
+subagents:
+  worker: forked
+`)
+	sub := filepath.Join(dir, SubagentsDir, "worker")
+	writeFile(t, filepath.Join(sub, ConfigFile), "name: worker\nmodel: m\n")
+
+	agent, err := Load(dir, nil)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := agent.GetHandoffMode("worker"); got != agents.ContextForked {
+		t.Errorf("worker mode = %v, want forked", got)
+	}
+}
+
+func TestLoadInvalidSubagentMode(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ConfigFile), "name: parent\nmodel: m\nsubagents:\n  worker: sideways\n")
+	writeFile(t, filepath.Join(dir, SubagentsDir, "worker", ConfigFile), "name: worker\nmodel: m\n")
+	if _, err := Load(dir, nil); err == nil {
+		t.Error("expected error for invalid subagent mode")
+	}
+}
+
+func TestLoadRemoteSkill(t *testing.T) {
+	body := "---\nname: remote\ndescription: A remote skill\n---\nbody"
+	sum := sha256.Sum256([]byte(body))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ConfigFile), "name: x\nmodel: m\nskills:\n  - source: "+srv.URL+"/s.md\n    sha256: "+hex.EncodeToString(sum[:])+"\n")
+
+	agent, err := LoadWithOptions(dir, nil, Options{
+		SkillCache:   t.TempDir(),
+		AllowedHosts: []string{"127.0.0.1"},
+	})
+	if err != nil {
+		t.Fatalf("LoadWithOptions: %v", err)
+	}
+	if len(agent.Skills) != 1 || agent.Skills[0].Name != "remote" {
+		t.Errorf("skills = %+v, want one 'remote' skill", agent.Skills)
 	}
 }
 

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -1,0 +1,108 @@
+package loader
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/tools"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testRegistry() *tools.Registry {
+	r := tools.NewRegistry()
+	r.MustRegister(tools.NewTool("ping", "pings", func(_ context.Context, _ map[string]interface{}) (interface{}, error) {
+		return "pong", nil
+	}))
+	return r
+}
+
+func TestLoadFullAgent(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, ConfigFile), `name: support
+provider: anthropic
+model: claude-sonnet-4-6
+temperature: 0.3
+max_tokens: 512
+tools:
+  - ping
+`)
+	writeFile(t, filepath.Join(dir, InstructionsFile), "You are support.")
+	writeFile(t, filepath.Join(dir, SkillsDir, "refunds.md"), "---\nname: refunds\ndescription: Refund flow\n---\nbody")
+
+	// A subagent.
+	sub := filepath.Join(dir, SubagentsDir, "billing")
+	writeFile(t, filepath.Join(sub, ConfigFile), "name: billing\nmodel: claude-sonnet-4-6\n")
+	writeFile(t, filepath.Join(sub, InstructionsFile), "You handle billing.")
+
+	agent, err := Load(dir, testRegistry())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if agent.Name != "support" {
+		t.Errorf("name = %q", agent.Name)
+	}
+	if agent.Provider != "anthropic" {
+		t.Errorf("provider = %q", agent.Provider)
+	}
+	if agent.Model != "claude-sonnet-4-6" {
+		t.Errorf("model = %q", agent.Model)
+	}
+	if agent.Temperature != 0.3 {
+		t.Errorf("temperature = %v", agent.Temperature)
+	}
+	if len(agent.Tools) != 1 || agent.Tools[0].Name() != "ping" {
+		t.Errorf("tools = %v", agent.Tools)
+	}
+	if len(agent.Skills) != 1 || agent.Skills[0].Name != "refunds" {
+		t.Errorf("skills = %v", agent.Skills)
+	}
+	if _, ok := agent.GetHandoff("billing"); !ok {
+		t.Error("expected billing subagent as handoff")
+	}
+
+	// The load_skill builtin should be exposed because the agent has skills.
+	var hasLoadSkill bool
+	for _, tool := range agent.EffectiveTools() {
+		if tool.Name() == "load_skill" {
+			hasLoadSkill = true
+		}
+	}
+	if !hasLoadSkill {
+		t.Error("expected load_skill builtin in EffectiveTools")
+	}
+}
+
+func TestLoadMissingConfig(t *testing.T) {
+	if _, err := Load(t.TempDir(), nil); err == nil {
+		t.Error("expected error for missing agent.yaml")
+	}
+}
+
+func TestLoadUnknownTool(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ConfigFile), "name: x\nmodel: m\ntools:\n  - nope\n")
+	if _, err := Load(dir, testRegistry()); err == nil {
+		t.Error("expected error for unknown tool")
+	}
+}
+
+func TestLoadToolsWithoutRegistry(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ConfigFile), "name: x\nmodel: m\ntools:\n  - ping\n")
+	if _, err := Load(dir, nil); err == nil {
+		t.Error("expected error when tools declared but no registry")
+	}
+}

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -18,6 +19,7 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/ryanhill4L/agents-sdk/pkg/tools"
+	"github.com/ryanhill4L/agents-sdk/pkg/tracing"
 )
 
 // Transport names.
@@ -59,10 +61,12 @@ type Client struct {
 	cfg     ServerConfig
 	session *mcpsdk.ClientSession
 	tools   []tools.Tool
+	logger  *slog.Logger
 }
 
-// Connect dials the server described by cfg and lists its tools.
-func Connect(ctx context.Context, cfg ServerConfig) (*Client, error) {
+// Connect dials the server described by cfg and lists its tools. A nil logger
+// disables logging.
+func Connect(ctx context.Context, cfg ServerConfig, logger *slog.Logger) (*Client, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -74,29 +78,33 @@ func Connect(ctx context.Context, cfg ServerConfig) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mcp server %q: %w", cfg.Name, err)
 	}
-	return connectTransport(ctx, cfg, transport)
+	return connectTransport(ctx, cfg, transport, logger)
 }
 
 // connectTransport connects a client over an arbitrary transport. It is the
 // shared core of Connect and is used by tests with in-memory transports.
-func connectTransport(ctx context.Context, cfg ServerConfig, transport mcpsdk.Transport) (*Client, error) {
+func connectTransport(ctx context.Context, cfg ServerConfig, transport mcpsdk.Transport, logger *slog.Logger) (*Client, error) {
+	log := tracing.OrDiscard(logger)
+
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, connectTimeout)
 		defer cancel()
 	}
 
+	log.Debug("mcp connecting", "server", cfg.Name, "transport", cfg.Transport)
 	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "agents-sdk", Version: "0.1.0"}, nil)
 	session, err := client.Connect(ctx, transport, nil)
 	if err != nil {
 		return nil, fmt.Errorf("mcp server %q: connect: %w", cfg.Name, err)
 	}
 
-	c := &Client{cfg: cfg, session: session}
+	c := &Client{cfg: cfg, session: session, logger: log}
 	if err := c.loadTools(ctx); err != nil {
 		_ = session.Close()
 		return nil, fmt.Errorf("mcp server %q: %w", cfg.Name, err)
 	}
+	log.Info("mcp connected", "server", cfg.Name, "tools", len(c.tools))
 	return c, nil
 }
 
@@ -126,13 +134,17 @@ func (c *Client) loadTools(ctx context.Context) error {
 		if len(allow) > 0 && !allow[t.Name] {
 			continue
 		}
+		name := namespaced(c.cfg.Name, t.Name)
 		c.tools = append(c.tools, &mcpTool{
 			session:     c.session,
 			rawName:     t.Name,
-			name:        namespaced(c.cfg.Name, t.Name),
+			name:        name,
 			description: t.Description,
 			schema:      convertSchema(t.InputSchema),
 		})
+		if c.logger != nil {
+			c.logger.Debug("mcp tool discovered", "server", c.cfg.Name, "tool", name)
+		}
 	}
 	return nil
 }

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -223,6 +223,11 @@ func sanitize(s string) string {
 }
 
 // convertSchema maps an MCP JSON-schema input into our ParameterSchema.
+//
+// TODO: this carries only per-property type/description; nested object
+// properties, array `items`, and `enum` constraints are dropped (a limitation
+// shared with tools.PropertySchema). Tools with rich array/object parameters
+// will be under-specified to the model until the schema type is enriched.
 func convertSchema(input any) tools.ParameterSchema {
 	schema := tools.ParameterSchema{
 		Type:       "object",

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -1,0 +1,254 @@
+// Package mcp connects an agent to Model Context Protocol (MCP) servers and
+// exposes their tools through the SDK's tools.Tool interface. Servers are
+// declared in configuration (never chosen by the model) and connected at load
+// time over either the stdio or streamable-HTTP transport, using the official
+// github.com/modelcontextprotocol/go-sdk client.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/tools"
+)
+
+// Transport names.
+const (
+	TransportStdio = "stdio"
+	TransportHTTP  = "http"
+)
+
+// connectTimeout bounds the initialization handshake when the caller's context
+// has no deadline, so a misbehaving server can't hang loading forever.
+const connectTimeout = 30 * time.Second
+
+// ServerConfig declares a single MCP server.
+type ServerConfig struct {
+	// Name namespaces the server's tools (exposed as "<name>_<tool>").
+	Name string `yaml:"name"`
+	// Transport is "stdio" or "http".
+	Transport string `yaml:"transport"`
+
+	// Command is the subprocess to run for the stdio transport, e.g.
+	// ["npx", "-y", "@modelcontextprotocol/server-github"].
+	Command []string `yaml:"command"`
+	// Env sets extra environment variables for a stdio server (in addition to
+	// the inherited process environment). Values are expanded with $VAR syntax.
+	Env map[string]string `yaml:"env"`
+
+	// URL is the endpoint for the http (streamable-HTTP) transport.
+	URL string `yaml:"url"`
+	// Headers are sent on every HTTP request. Values are expanded with $VAR.
+	Headers map[string]string `yaml:"headers"`
+
+	// Tools optionally restricts which of the server's tools are exposed
+	// (by raw tool name). Empty means expose all.
+	Tools []string `yaml:"tools"`
+}
+
+// Client is a connected MCP session and its adapted tools.
+type Client struct {
+	cfg     ServerConfig
+	session *mcpsdk.ClientSession
+	tools   []tools.Tool
+}
+
+// Connect dials the server described by cfg and lists its tools.
+func Connect(ctx context.Context, cfg ServerConfig) (*Client, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if cfg.Name == "" {
+		return nil, fmt.Errorf("mcp server is missing a name")
+	}
+
+	transport, err := cfg.transport()
+	if err != nil {
+		return nil, fmt.Errorf("mcp server %q: %w", cfg.Name, err)
+	}
+	return connectTransport(ctx, cfg, transport)
+}
+
+// connectTransport connects a client over an arbitrary transport. It is the
+// shared core of Connect and is used by tests with in-memory transports.
+func connectTransport(ctx context.Context, cfg ServerConfig, transport mcpsdk.Transport) (*Client, error) {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, connectTimeout)
+		defer cancel()
+	}
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "agents-sdk", Version: "0.1.0"}, nil)
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		return nil, fmt.Errorf("mcp server %q: connect: %w", cfg.Name, err)
+	}
+
+	c := &Client{cfg: cfg, session: session}
+	if err := c.loadTools(ctx); err != nil {
+		_ = session.Close()
+		return nil, fmt.Errorf("mcp server %q: %w", cfg.Name, err)
+	}
+	return c, nil
+}
+
+// Tools returns the server's tools adapted to the tools.Tool interface.
+func (c *Client) Tools() []tools.Tool { return c.tools }
+
+// Close terminates the session (and, for stdio, the subprocess).
+func (c *Client) Close() error {
+	if c.session == nil {
+		return nil
+	}
+	return c.session.Close()
+}
+
+func (c *Client) loadTools(ctx context.Context) error {
+	allow := map[string]bool{}
+	for _, name := range c.cfg.Tools {
+		allow[name] = true
+	}
+
+	res, err := c.session.ListTools(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("listing tools: %w", err)
+	}
+
+	for _, t := range res.Tools {
+		if len(allow) > 0 && !allow[t.Name] {
+			continue
+		}
+		c.tools = append(c.tools, &mcpTool{
+			session:     c.session,
+			rawName:     t.Name,
+			name:        namespaced(c.cfg.Name, t.Name),
+			description: t.Description,
+			schema:      convertSchema(t.InputSchema),
+		})
+	}
+	return nil
+}
+
+// transport builds the SDK transport for this server config.
+func (cfg ServerConfig) transport() (mcpsdk.Transport, error) {
+	switch strings.ToLower(cfg.Transport) {
+	case TransportStdio, "":
+		if len(cfg.Command) == 0 {
+			return nil, fmt.Errorf("stdio transport requires a command")
+		}
+		cmd := exec.Command(cfg.Command[0], cfg.Command[1:]...)
+		cmd.Env = os.Environ()
+		for k, v := range cfg.Env {
+			cmd.Env = append(cmd.Env, k+"="+os.ExpandEnv(v))
+		}
+		return &mcpsdk.CommandTransport{Command: cmd}, nil
+
+	case TransportHTTP:
+		if cfg.URL == "" {
+			return nil, fmt.Errorf("http transport requires a url")
+		}
+		return &mcpsdk.StreamableClientTransport{
+			Endpoint:   cfg.URL,
+			HTTPClient: httpClient(cfg.Headers),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown transport %q (use stdio or http)", cfg.Transport)
+	}
+}
+
+func httpClient(headers map[string]string) *http.Client {
+	if len(headers) == 0 {
+		return nil // SDK uses its default client
+	}
+	expanded := make(map[string]string, len(headers))
+	for k, v := range headers {
+		expanded[k] = os.ExpandEnv(v)
+	}
+	return &http.Client{Transport: &headerRoundTripper{base: http.DefaultTransport, headers: expanded}}
+}
+
+type headerRoundTripper struct {
+	base    http.RoundTripper
+	headers map[string]string
+}
+
+func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	for k, v := range h.headers {
+		req.Header.Set(k, v)
+	}
+	return h.base.RoundTrip(req)
+}
+
+// namespaced prefixes a tool name with its server, sanitized to characters
+// accepted by provider tool-name schemas.
+func namespaced(server, tool string) string {
+	if server == "" {
+		return tool
+	}
+	return sanitize(server) + "_" + tool
+}
+
+func sanitize(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// convertSchema maps an MCP JSON-schema input into our ParameterSchema.
+func convertSchema(input any) tools.ParameterSchema {
+	schema := tools.ParameterSchema{
+		Type:       "object",
+		Properties: map[string]tools.PropertySchema{},
+		Required:   []string{},
+	}
+	if input == nil {
+		return schema
+	}
+
+	raw, err := json.Marshal(input)
+	if err != nil {
+		return schema
+	}
+	var parsed struct {
+		Type       string `json:"type"`
+		Properties map[string]struct {
+			Type        string `json:"type"`
+			Description string `json:"description"`
+		} `json:"properties"`
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return schema
+	}
+
+	if parsed.Type != "" {
+		schema.Type = parsed.Type
+	}
+	for name, p := range parsed.Properties {
+		typ := p.Type
+		if typ == "" {
+			typ = "string"
+		}
+		schema.Properties[name] = tools.PropertySchema{Type: typ, Description: p.Description}
+	}
+	if parsed.Required != nil {
+		schema.Required = parsed.Required
+	}
+	return schema
+}

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -1,0 +1,96 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type echoIn struct {
+	Message string `json:"message" jsonschema:"the message to echo"`
+}
+
+// startTestServer spins up an in-memory MCP server exposing an "echo" tool and
+// returns a connected Client.
+func startTestServer(t *testing.T, cfg ServerConfig) *Client {
+	t.Helper()
+
+	server := mcpsdk.NewServer(&mcpsdk.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	mcpsdk.AddTool(server, &mcpsdk.Tool{Name: "echo", Description: "Echoes the message"},
+		func(_ context.Context, _ *mcpsdk.CallToolRequest, in echoIn) (*mcpsdk.CallToolResult, any, error) {
+			return &mcpsdk.CallToolResult{
+				Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: "echo: " + in.Message}},
+			}, nil, nil
+		})
+
+	serverTransport, clientTransport := mcpsdk.NewInMemoryTransports()
+	if _, err := server.Connect(context.Background(), serverTransport, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+
+	client, err := connectTransport(context.Background(), cfg, clientTransport)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func TestMCPToolAdaptation(t *testing.T) {
+	client := startTestServer(t, ServerConfig{Name: "demo"})
+
+	tls := client.Tools()
+	if len(tls) != 1 {
+		t.Fatalf("got %d tools, want 1", len(tls))
+	}
+	tool := tls[0]
+
+	if tool.Name() != "demo_echo" {
+		t.Errorf("tool name = %q, want demo_echo (namespaced)", tool.Name())
+	}
+	if tool.Description() != "Echoes the message" {
+		t.Errorf("description = %q", tool.Description())
+	}
+	if _, ok := tool.Schema().Properties["message"]; !ok {
+		t.Errorf("schema missing 'message' property: %+v", tool.Schema())
+	}
+
+	out, err := tool.Execute(context.Background(), map[string]interface{}{"message": "hi"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fmt.Sprintf("%v", out) != "echo: hi" {
+		t.Errorf("output = %v, want 'echo: hi'", out)
+	}
+}
+
+func TestMCPToolAllowlist(t *testing.T) {
+	// Restrict to a tool that does not exist -> no tools exposed.
+	client := startTestServer(t, ServerConfig{Name: "demo", Tools: []string{"nonexistent"}})
+	if len(client.Tools()) != 0 {
+		t.Errorf("expected allowlist to exclude all tools, got %d", len(client.Tools()))
+	}
+}
+
+func TestTransportValidation(t *testing.T) {
+	if _, err := (ServerConfig{Name: "x", Transport: "stdio"}).transport(); err == nil {
+		t.Error("expected error for stdio with no command")
+	}
+	if _, err := (ServerConfig{Name: "x", Transport: "http"}).transport(); err == nil {
+		t.Error("expected error for http with no url")
+	}
+	if _, err := (ServerConfig{Name: "x", Transport: "carrier-pigeon"}).transport(); err == nil {
+		t.Error("expected error for unknown transport")
+	}
+}
+
+func TestNamespaced(t *testing.T) {
+	if got := namespaced("git hub", "create.issue"); got != "git_hub_create.issue" {
+		t.Errorf("namespaced = %q", got)
+	}
+	if got := namespaced("", "tool"); got != "tool" {
+		t.Errorf("namespaced empty server = %q, want 'tool'", got)
+	}
+}

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -30,7 +30,7 @@ func startTestServer(t *testing.T, cfg ServerConfig) *Client {
 		t.Fatalf("server connect: %v", err)
 	}
 
-	client, err := connectTransport(context.Background(), cfg, clientTransport)
+	client, err := connectTransport(context.Background(), cfg, clientTransport, nil)
 	if err != nil {
 		t.Fatalf("client connect: %v", err)
 	}

--- a/pkg/mcp/tool.go
+++ b/pkg/mcp/tool.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -77,11 +78,12 @@ type Manager struct {
 }
 
 // ConnectAll connects to every server in cfgs. If any connection fails, all
-// already-opened connections are closed and the error is returned.
-func ConnectAll(ctx context.Context, cfgs []ServerConfig) (*Manager, error) {
+// already-opened connections are closed and the error is returned. A nil logger
+// disables logging.
+func ConnectAll(ctx context.Context, cfgs []ServerConfig, logger *slog.Logger) (*Manager, error) {
 	m := &Manager{}
 	for _, cfg := range cfgs {
-		client, err := Connect(ctx, cfg)
+		client, err := Connect(ctx, cfg, logger)
 		if err != nil {
 			_ = m.Close()
 			return nil, err

--- a/pkg/mcp/tool.go
+++ b/pkg/mcp/tool.go
@@ -1,0 +1,112 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/tools"
+)
+
+// mcpTool adapts a single MCP server tool to the tools.Tool interface.
+type mcpTool struct {
+	session     *mcpsdk.ClientSession
+	rawName     string // name on the server, used for tools/call
+	name        string // namespaced name exposed to the model
+	description string
+	schema      tools.ParameterSchema
+}
+
+func (t *mcpTool) Name() string                  { return t.name }
+func (t *mcpTool) Description() string           { return t.description }
+func (t *mcpTool) Schema() tools.ParameterSchema { return t.schema }
+
+func (t *mcpTool) Validate() error {
+	if t.session == nil {
+		return fmt.Errorf("mcp tool %q has no session", t.name)
+	}
+	if t.rawName == "" {
+		return fmt.Errorf("mcp tool is missing a name")
+	}
+	return nil
+}
+
+// Execute invokes the tool on the server and returns its text content.
+func (t *mcpTool) Execute(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	res, err := t.session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      t.rawName,
+		Arguments: args,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mcp tool %q: %w", t.name, err)
+	}
+
+	text := textContent(res)
+	if res.IsError {
+		if text == "" {
+			text = "tool call failed"
+		}
+		return nil, fmt.Errorf("mcp tool %q: %s", t.name, text)
+	}
+
+	// Prefer structured content when present; otherwise return the text.
+	if res.StructuredContent != nil {
+		return res.StructuredContent, nil
+	}
+	return text, nil
+}
+
+func textContent(res *mcpsdk.CallToolResult) string {
+	var b strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcpsdk.TextContent); ok {
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+// Manager holds connections to multiple MCP servers and aggregates their tools.
+type Manager struct {
+	clients []*Client
+}
+
+// ConnectAll connects to every server in cfgs. If any connection fails, all
+// already-opened connections are closed and the error is returned.
+func ConnectAll(ctx context.Context, cfgs []ServerConfig) (*Manager, error) {
+	m := &Manager{}
+	for _, cfg := range cfgs {
+		client, err := Connect(ctx, cfg)
+		if err != nil {
+			_ = m.Close()
+			return nil, err
+		}
+		m.clients = append(m.clients, client)
+	}
+	return m, nil
+}
+
+// Tools returns the combined tools from every connected server.
+func (m *Manager) Tools() []tools.Tool {
+	var all []tools.Tool
+	for _, c := range m.clients {
+		all = append(all, c.Tools()...)
+	}
+	return all
+}
+
+// Close closes all server connections, returning the first error encountered.
+func (m *Manager) Close() error {
+	var firstErr error
+	for _, c := range m.clients {
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/pkg/providers/resolve.go
+++ b/pkg/providers/resolve.go
@@ -1,0 +1,51 @@
+package providers
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Resolve constructs a provider from a short name using credentials found in the
+// environment. Supported names: "openai", "anthropic", "gemini", "ollama".
+//
+// An empty name falls back to PROVIDER, then auto-detects based on which API key
+// is set, and finally defaults to "openai".
+func Resolve(name string) (Provider, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		name = strings.ToLower(strings.TrimSpace(os.Getenv("PROVIDER")))
+	}
+	if name == "" {
+		name = autodetect()
+	}
+
+	switch name {
+	case "openai":
+		return NewOpenAIProviderFromEnv()
+	case "anthropic", "claude":
+		return NewAnthropicProviderFromEnv()
+	case "gemini", "google":
+		return NewGeminiProviderFromEnv()
+	case "ollama":
+		return NewOllamaProviderFromEnv()
+	default:
+		return nil, fmt.Errorf("%w: %q", ErrUnsupportedProvider, name)
+	}
+}
+
+// autodetect picks a provider based on which credentials are present.
+func autodetect() string {
+	switch {
+	case os.Getenv("OPENAI_API_KEY") != "":
+		return "openai"
+	case os.Getenv("ANTHROPIC_API_KEY") != "":
+		return "anthropic"
+	case os.Getenv("GEMINI_API_KEY") != "":
+		return "gemini"
+	case os.Getenv("OLLAMA_HOST") != "":
+		return "ollama"
+	default:
+		return "openai"
+	}
+}

--- a/pkg/schedules/schedule.go
+++ b/pkg/schedules/schedule.go
@@ -96,25 +96,37 @@ func Run(ctx context.Context, scheds []Schedule, trigger TriggerFunc) error {
 	}
 
 	// Align to the next minute boundary, then tick every minute.
-	now := time.Now()
-	next := now.Truncate(time.Minute).Add(time.Minute)
-	timer := time.NewTimer(time.Until(next))
+	timer := time.NewTimer(time.Until(time.Now().Truncate(time.Minute).Add(time.Minute)))
 	defer timer.Stop()
+
+	// Triggers run in their own goroutines so a long-running trigger (e.g. an
+	// LLM call) cannot block or skip subsequent ticks. The first trigger error
+	// is surfaced and stops the scheduler.
+	errCh := make(chan error, 1)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case err := <-errCh:
+			return err
 		case t := <-timer.C:
 			for _, s := range scheds {
 				if s.Matches(t) {
-					if err := trigger(ctx, s); err != nil {
-						return err
-					}
+					s := s
+					go func() {
+						if err := trigger(ctx, s); err != nil {
+							select {
+							case errCh <- err:
+							default:
+							}
+						}
+					}()
 				}
 			}
-			next = next.Add(time.Minute)
-			timer.Reset(time.Until(next))
+			// Re-align to the next boundary from now so a slow tick doesn't
+			// build a backlog or drift.
+			timer.Reset(time.Until(time.Now().Truncate(time.Minute).Add(time.Minute)))
 		}
 	}
 }
@@ -177,9 +189,14 @@ func parseCron(expr string) (cronSchedule, error) {
 	if err != nil {
 		return cronSchedule{}, fmt.Errorf("month: %w", err)
 	}
-	dow, err := parseField(fields[4], 0, 6)
+	// Day-of-week accepts 0-7 where both 0 and 7 mean Sunday; fold 7 into 0.
+	dow, err := parseField(fields[4], 0, 7)
 	if err != nil {
 		return cronSchedule{}, fmt.Errorf("day-of-week: %w", err)
+	}
+	if dow[7] {
+		dow[0] = true
+		delete(dow, 7)
 	}
 
 	return cronSchedule{

--- a/pkg/schedules/schedule.go
+++ b/pkg/schedules/schedule.go
@@ -1,0 +1,244 @@
+// Package schedules implements Eve-style scheduled triggers: an agent can be
+// woken on a cron expression with a fixed input. It includes a small,
+// dependency-free cron matcher supporting the standard five fields
+// (minute hour day-of-month month day-of-week) with "*", lists ("1,2"),
+// ranges ("1-5"), and steps ("*/15").
+package schedules
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Schedule binds a cron expression to an input string.
+type Schedule struct {
+	Name  string `yaml:"name"`
+	Cron  string `yaml:"cron"`
+	Input string `yaml:"input"`
+
+	schedule cronSchedule
+}
+
+// LoadDir loads every *.yaml file in dir as a schedule. A missing directory is
+// not an error.
+func LoadDir(dir string) ([]Schedule, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var out []Schedule
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		var s Schedule
+		if err := yaml.Unmarshal(data, &s); err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		if s.Name == "" {
+			base := filepath.Base(path)
+			s.Name = strings.TrimSuffix(base, filepath.Ext(base))
+		}
+		if err := s.compile(); err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func (s *Schedule) compile() error {
+	cs, err := parseCron(s.Cron)
+	if err != nil {
+		return err
+	}
+	s.schedule = cs
+	return nil
+}
+
+// Matches reports whether the schedule should fire at time t (minute precision).
+func (s *Schedule) Matches(t time.Time) bool {
+	return s.schedule.matches(t)
+}
+
+// TriggerFunc handles a fired schedule.
+type TriggerFunc func(ctx context.Context, s Schedule) error
+
+// Run blocks, ticking once per minute, and invokes trigger for every schedule
+// whose cron matches the current minute. It returns when ctx is cancelled.
+func Run(ctx context.Context, scheds []Schedule, trigger TriggerFunc) error {
+	for i := range scheds {
+		if err := scheds[i].compile(); err != nil {
+			return err
+		}
+	}
+
+	// Align to the next minute boundary, then tick every minute.
+	now := time.Now()
+	next := now.Truncate(time.Minute).Add(time.Minute)
+	timer := time.NewTimer(time.Until(next))
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case t := <-timer.C:
+			for _, s := range scheds {
+				if s.Matches(t) {
+					if err := trigger(ctx, s); err != nil {
+						return err
+					}
+				}
+			}
+			next = next.Add(time.Minute)
+			timer.Reset(time.Until(next))
+		}
+	}
+}
+
+// cronSchedule is a compiled 5-field cron expression.
+type cronSchedule struct {
+	minute     fieldSet
+	hour       fieldSet
+	dayOfMonth fieldSet
+	month      fieldSet
+	dayOfWeek  fieldSet
+}
+
+type fieldSet map[int]bool
+
+func (s cronSchedule) matches(t time.Time) bool {
+	dom := s.dayOfMonth[t.Day()]
+	dow := s.dayOfWeek[int(t.Weekday())]
+
+	// Standard cron semantics: when both DOM and DOW are restricted, a match on
+	// either is sufficient; otherwise both must match.
+	var dayMatch bool
+	if s.dayOfMonth.restricted(1, 31) && s.dayOfWeek.restricted(0, 6) {
+		dayMatch = dom || dow
+	} else {
+		dayMatch = dom && dow
+	}
+
+	return s.minute[t.Minute()] &&
+		s.hour[t.Hour()] &&
+		s.month[int(t.Month())] &&
+		dayMatch
+}
+
+// restricted reports whether the field does not cover the full [min,max] range.
+func (f fieldSet) restricted(min, max int) bool {
+	return len(f) != (max - min + 1)
+}
+
+// parseCron parses a standard five-field cron expression.
+func parseCron(expr string) (cronSchedule, error) {
+	fields := strings.Fields(expr)
+	if len(fields) != 5 {
+		return cronSchedule{}, fmt.Errorf("cron must have 5 fields, got %d: %q", len(fields), expr)
+	}
+
+	minute, err := parseField(fields[0], 0, 59)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("minute: %w", err)
+	}
+	hour, err := parseField(fields[1], 0, 23)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("hour: %w", err)
+	}
+	dom, err := parseField(fields[2], 1, 31)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("day-of-month: %w", err)
+	}
+	month, err := parseField(fields[3], 1, 12)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("month: %w", err)
+	}
+	dow, err := parseField(fields[4], 0, 6)
+	if err != nil {
+		return cronSchedule{}, fmt.Errorf("day-of-week: %w", err)
+	}
+
+	return cronSchedule{
+		minute:     minute,
+		hour:       hour,
+		dayOfMonth: dom,
+		month:      month,
+		dayOfWeek:  dow,
+	}, nil
+}
+
+// parseField parses a single cron field (lists, ranges, steps, wildcards).
+func parseField(field string, min, max int) (fieldSet, error) {
+	set := make(fieldSet)
+	for _, part := range strings.Split(field, ",") {
+		step := 1
+		rangePart := part
+		if slash := strings.Index(part, "/"); slash >= 0 {
+			stepStr := part[slash+1:]
+			rangePart = part[:slash]
+			s, err := strconv.Atoi(stepStr)
+			if err != nil || s <= 0 {
+				return nil, fmt.Errorf("invalid step %q", stepStr)
+			}
+			step = s
+		}
+
+		lo, hi := min, max
+		switch {
+		case rangePart == "*":
+			// full range
+		case strings.Contains(rangePart, "-"):
+			bounds := strings.SplitN(rangePart, "-", 2)
+			a, err := strconv.Atoi(bounds[0])
+			if err != nil {
+				return nil, fmt.Errorf("invalid range start %q", bounds[0])
+			}
+			b, err := strconv.Atoi(bounds[1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid range end %q", bounds[1])
+			}
+			lo, hi = a, b
+		default:
+			v, err := strconv.Atoi(rangePart)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value %q", rangePart)
+			}
+			lo, hi = v, v
+		}
+
+		if lo < min || hi > max || lo > hi {
+			return nil, fmt.Errorf("value out of range [%d,%d]: %q", min, max, part)
+		}
+		for v := lo; v <= hi; v += step {
+			set[v] = true
+		}
+	}
+	if len(set) == 0 {
+		return nil, fmt.Errorf("empty field %q", field)
+	}
+	return set, nil
+}

--- a/pkg/schedules/schedule_test.go
+++ b/pkg/schedules/schedule_test.go
@@ -56,6 +56,16 @@ func TestCronList(t *testing.T) {
 	}
 }
 
+func TestCronSundayBothForms(t *testing.T) {
+	sunday := time.Date(2024, 1, 7, 9, 0, 0, 0, time.UTC) // a Sunday
+	for _, expr := range []string{"0 9 * * 0", "0 9 * * 7"} {
+		s := mustCompile(t, expr)
+		if !s.Matches(sunday) {
+			t.Errorf("%q should match Sunday 09:00", expr)
+		}
+	}
+}
+
 func TestCronInvalid(t *testing.T) {
 	for _, expr := range []string{"", "1 2 3", "60 * * * *", "* * * * 9", "*/0 * * * *"} {
 		s := Schedule{Cron: expr}

--- a/pkg/schedules/schedule_test.go
+++ b/pkg/schedules/schedule_test.go
@@ -1,0 +1,66 @@
+package schedules
+
+import (
+	"testing"
+	"time"
+)
+
+func mustCompile(t *testing.T, expr string) Schedule {
+	t.Helper()
+	s := Schedule{Cron: expr}
+	if err := s.compile(); err != nil {
+		t.Fatalf("compile(%q): %v", expr, err)
+	}
+	return s
+}
+
+func TestCronMatches(t *testing.T) {
+	// 09:00 on weekdays. 2024-01-01 is a Monday.
+	s := mustCompile(t, "0 9 * * 1-5")
+
+	monday9 := time.Date(2024, 1, 1, 9, 0, 0, 0, time.UTC)
+	if !s.Matches(monday9) {
+		t.Error("expected match at Monday 09:00")
+	}
+	if s.Matches(monday9.Add(time.Minute)) {
+		t.Error("did not expect match at 09:01")
+	}
+
+	saturday9 := time.Date(2024, 1, 6, 9, 0, 0, 0, time.UTC)
+	if s.Matches(saturday9) {
+		t.Error("did not expect match on Saturday")
+	}
+}
+
+func TestCronStep(t *testing.T) {
+	s := mustCompile(t, "*/15 * * * *")
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, m := range []int{0, 15, 30, 45} {
+		if !s.Matches(base.Add(time.Duration(m) * time.Minute)) {
+			t.Errorf("expected match at minute %d", m)
+		}
+	}
+	if s.Matches(base.Add(7 * time.Minute)) {
+		t.Error("did not expect match at minute 7")
+	}
+}
+
+func TestCronList(t *testing.T) {
+	s := mustCompile(t, "0,30 12 * * *")
+	noon := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	if !s.Matches(noon) || !s.Matches(noon.Add(30*time.Minute)) {
+		t.Error("expected matches at 12:00 and 12:30")
+	}
+	if s.Matches(noon.Add(15 * time.Minute)) {
+		t.Error("did not expect match at 12:15")
+	}
+}
+
+func TestCronInvalid(t *testing.T) {
+	for _, expr := range []string{"", "1 2 3", "60 * * * *", "* * * * 9", "*/0 * * * *"} {
+		s := Schedule{Cron: expr}
+		if err := s.compile(); err == nil {
+			t.Errorf("expected error for %q", expr)
+		}
+	}
+}

--- a/pkg/skills/remote.go
+++ b/pkg/skills/remote.go
@@ -1,0 +1,237 @@
+package skills
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// RemoteSource declares a skill fetched from a remote location. Sources are
+// declared by the developer (never supplied by the model) and are resolved at
+// load time, so a malicious skill cannot be injected at runtime.
+//
+// Supported source forms:
+//   - github.com/<org>/<repo>/<path...>  (requires Ref, a commit SHA)
+//   - https://<host>/<path...>           (a direct URL; pin it yourself)
+//
+// Always set Ref to an immutable commit SHA for GitHub sources, and prefer
+// setting SHA256 so the fetched bytes are integrity-checked.
+type RemoteSource struct {
+	Source string `yaml:"source"`
+	Ref    string `yaml:"ref"`
+	SHA256 string `yaml:"sha256"`
+	Name   string `yaml:"name"`
+}
+
+// FetchOptions configures remote skill fetching.
+type FetchOptions struct {
+	// CacheDir is where fetched skills are cached. Empty uses the OS cache dir.
+	CacheDir string
+	// AllowedHosts restricts which hosts may be fetched. Empty uses
+	// DefaultAllowedHosts.
+	AllowedHosts []string
+	// Client is the HTTP client to use. Empty uses a client with a 30s timeout.
+	Client *http.Client
+}
+
+// DefaultAllowedHosts is the conservative default allowlist of skill hosts.
+var DefaultAllowedHosts = []string{
+	"raw.githubusercontent.com",
+	"gist.githubusercontent.com",
+}
+
+// FetchRemote resolves, fetches (or reads from cache), integrity-checks, and
+// parses a single remote skill.
+func FetchRemote(ctx context.Context, src RemoteSource, opts FetchOptions) (Skill, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	rawURL, err := resolveURL(src)
+	if err != nil {
+		return Skill{}, err
+	}
+	if err := checkHost(rawURL, allowedHosts(opts)); err != nil {
+		return Skill{}, err
+	}
+
+	cacheDir, err := resolveCacheDir(opts.CacheDir)
+	if err != nil {
+		return Skill{}, err
+	}
+	cachePath := filepath.Join(cacheDir, cacheKey(src)+".md")
+
+	data, err := readCache(cachePath, src.SHA256)
+	if err != nil {
+		return Skill{}, err
+	}
+	if data == nil {
+		data, err = download(ctx, rawURL, opts)
+		if err != nil {
+			return Skill{}, err
+		}
+		if err := verifyChecksum(data, src.SHA256); err != nil {
+			return Skill{}, fmt.Errorf("skill %s: %w", src.Source, err)
+		}
+		if err := writeCache(cachePath, data); err != nil {
+			return Skill{}, err
+		}
+	}
+
+	defaultName := src.Name
+	if defaultName == "" {
+		base := path.Base(strings.TrimRight(src.Source, "/"))
+		defaultName = strings.TrimSuffix(base, filepath.Ext(base))
+	}
+	skill, err := Parse(data, defaultName)
+	if err != nil {
+		return Skill{}, fmt.Errorf("skill %s: %w", src.Source, err)
+	}
+	if src.Name != "" {
+		skill.Name = src.Name
+	}
+	skill.Path = rawURL
+	return skill, nil
+}
+
+// FetchAll fetches every remote source, preserving order.
+func FetchAll(ctx context.Context, srcs []RemoteSource, opts FetchOptions) ([]Skill, error) {
+	out := make([]Skill, 0, len(srcs))
+	for _, src := range srcs {
+		s, err := FetchRemote(ctx, src, opts)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// resolveURL turns a source (GitHub shorthand or direct URL) into a fetch URL.
+func resolveURL(src RemoteSource) (string, error) {
+	source := strings.TrimSpace(src.Source)
+	if source == "" {
+		return "", fmt.Errorf("remote skill is missing a source")
+	}
+
+	if strings.HasPrefix(source, "github.com/") {
+		if strings.TrimSpace(src.Ref) == "" {
+			return "", fmt.Errorf("github skill %q requires a 'ref' (commit SHA)", source)
+		}
+		rest := strings.TrimPrefix(source, "github.com/")
+		parts := strings.SplitN(rest, "/", 3)
+		if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+			return "", fmt.Errorf("github skill %q must be github.com/<org>/<repo>/<path>", source)
+		}
+		return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s",
+			parts[0], parts[1], src.Ref, parts[2]), nil
+	}
+
+	if strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "http://") {
+		return source, nil
+	}
+
+	return "", fmt.Errorf("unsupported skill source %q (use github.com/... or an https:// URL)", source)
+}
+
+func allowedHosts(opts FetchOptions) []string {
+	if len(opts.AllowedHosts) > 0 {
+		return opts.AllowedHosts
+	}
+	return DefaultAllowedHosts
+}
+
+func checkHost(rawURL string, allowed []string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid skill URL %q: %w", rawURL, err)
+	}
+	for _, h := range allowed {
+		if strings.EqualFold(u.Hostname(), h) {
+			return nil
+		}
+	}
+	return fmt.Errorf("skill host %q is not in the allowlist %v", u.Hostname(), allowed)
+}
+
+func resolveCacheDir(dir string) (string, error) {
+	if dir == "" {
+		base, err := os.UserCacheDir()
+		if err != nil {
+			base = os.TempDir()
+		}
+		dir = filepath.Join(base, "agents-sdk", "skills")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+func cacheKey(src RemoteSource) string {
+	sum := sha256.Sum256([]byte(src.Source + "@" + src.Ref))
+	return hex.EncodeToString(sum[:])
+}
+
+// readCache returns cached bytes if present and (when wantSHA is set) matching;
+// it returns (nil, nil) on a miss so the caller fetches fresh.
+func readCache(cachePath, wantSHA string) ([]byte, error) {
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if wantSHA != "" {
+		if verifyChecksum(data, wantSHA) != nil {
+			return nil, nil // stale cache; refetch
+		}
+	}
+	return data, nil
+}
+
+func writeCache(cachePath string, data []byte) error {
+	return os.WriteFile(cachePath, data, 0o644)
+}
+
+func download(ctx context.Context, rawURL string, opts FetchOptions) ([]byte, error) {
+	client := opts.Client
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching skill %s: %w", rawURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching skill %s: unexpected status %d", rawURL, resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
+}
+
+func verifyChecksum(data []byte, wantSHA string) error {
+	if wantSHA == "" {
+		return nil
+	}
+	sum := sha256.Sum256(data)
+	got := hex.EncodeToString(sum[:])
+	if !strings.EqualFold(got, strings.TrimSpace(wantSHA)) {
+		return fmt.Errorf("checksum mismatch: got %s, want %s", got, wantSHA)
+	}
+	return nil
+}

--- a/pkg/skills/remote.go
+++ b/pkg/skills/remote.go
@@ -25,6 +25,11 @@ import (
 //
 // Always set Ref to an immutable commit SHA for GitHub sources, and prefer
 // setting SHA256 so the fetched bytes are integrity-checked.
+//
+// Security note: Ref is only required to be non-empty. Pointing it at a mutable
+// branch or tag (rather than a commit SHA) defeats the immutability guarantee —
+// the upstream content can change underneath you. Without SHA256, cached bytes
+// are served without revalidation. Pin a SHA for anything you don't control.
 type RemoteSource struct {
 	Source string `yaml:"source"`
 	Ref    string `yaml:"ref"`
@@ -68,14 +73,16 @@ func FetchRemote(ctx context.Context, src RemoteSource, opts FetchOptions) (Skil
 	if err != nil {
 		return Skill{}, err
 	}
-	cachePath := filepath.Join(cacheDir, cacheKey(src)+".md")
+	// Key the cache by the fully resolved URL so distinct sources/refs can never
+	// collide on a single cache entry.
+	cachePath := filepath.Join(cacheDir, cacheKey(rawURL)+".md")
 
 	data, err := readCache(cachePath, src.SHA256)
 	if err != nil {
 		return Skill{}, err
 	}
 	if data == nil {
-		data, err = download(ctx, rawURL, opts)
+		data, err = download(ctx, rawURL, opts, allowedHosts(opts))
 		if err != nil {
 			return Skill{}, err
 		}
@@ -171,14 +178,15 @@ func resolveCacheDir(dir string) (string, error) {
 		}
 		dir = filepath.Join(base, "agents-sdk", "skills")
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	// Integrity-sensitive: keep the cache private to the user.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
 	return dir, nil
 }
 
-func cacheKey(src RemoteSource) string {
-	sum := sha256.Sum256([]byte(src.Source + "@" + src.Ref))
+func cacheKey(rawURL string) string {
+	sum := sha256.Sum256([]byte(rawURL))
 	return hex.EncodeToString(sum[:])
 }
 
@@ -201,13 +209,23 @@ func readCache(cachePath, wantSHA string) ([]byte, error) {
 }
 
 func writeCache(cachePath string, data []byte) error {
-	return os.WriteFile(cachePath, data, 0o644)
+	return os.WriteFile(cachePath, data, 0o600)
 }
 
-func download(ctx context.Context, rawURL string, opts FetchOptions) ([]byte, error) {
+func download(ctx context.Context, rawURL string, opts FetchOptions, allowed []string) ([]byte, error) {
 	client := opts.Client
 	if client == nil {
-		client = &http.Client{Timeout: 30 * time.Second}
+		// Re-check redirect targets against the allowlist so it stays a real
+		// boundary even when a server redirects cross-host.
+		client = &http.Client{
+			Timeout: 30 * time.Second,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= 10 {
+					return fmt.Errorf("stopped after 10 redirects")
+				}
+				return checkHost(req.URL.String(), allowed)
+			},
+		}
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {

--- a/pkg/skills/remote_test.go
+++ b/pkg/skills/remote_test.go
@@ -1,0 +1,108 @@
+package skills
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const remoteSkillBody = "---\nname: remote-skill\ndescription: A remote skill\n---\nremote body"
+
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func TestFetchRemoteSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(remoteSkillBody))
+	}))
+	defer srv.Close()
+
+	src := RemoteSource{Source: srv.URL + "/skill.md", SHA256: sha256Hex(remoteSkillBody)}
+	opts := FetchOptions{CacheDir: t.TempDir(), AllowedHosts: []string{"127.0.0.1"}}
+
+	skill, err := FetchRemote(context.Background(), src, opts)
+	if err != nil {
+		t.Fatalf("FetchRemote: %v", err)
+	}
+	if skill.Name != "remote-skill" || skill.Content != "remote body" {
+		t.Errorf("unexpected skill: %+v", skill)
+	}
+}
+
+func TestFetchRemoteChecksumMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(remoteSkillBody))
+	}))
+	defer srv.Close()
+
+	src := RemoteSource{Source: srv.URL + "/skill.md", SHA256: sha256Hex("something else")}
+	opts := FetchOptions{CacheDir: t.TempDir(), AllowedHosts: []string{"127.0.0.1"}}
+
+	if _, err := FetchRemote(context.Background(), src, opts); err == nil {
+		t.Fatal("expected checksum mismatch error")
+	}
+}
+
+func TestFetchRemoteHostNotAllowed(t *testing.T) {
+	src := RemoteSource{Source: "https://evil.example.com/skill.md"}
+	// Default allowlist excludes evil.example.com.
+	if _, err := FetchRemote(context.Background(), src, FetchOptions{CacheDir: t.TempDir()}); err == nil {
+		t.Fatal("expected host-not-allowed error")
+	}
+}
+
+func TestFetchRemoteUsesCache(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_, _ = w.Write([]byte(remoteSkillBody))
+	}))
+
+	cache := t.TempDir()
+	src := RemoteSource{Source: srv.URL + "/skill.md", SHA256: sha256Hex(remoteSkillBody)}
+	opts := FetchOptions{CacheDir: cache, AllowedHosts: []string{"127.0.0.1"}}
+
+	if _, err := FetchRemote(context.Background(), src, opts); err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	srv.Close() // second fetch must come from cache
+
+	skill, err := FetchRemote(context.Background(), src, opts)
+	if err != nil {
+		t.Fatalf("cached fetch: %v", err)
+	}
+	if skill.Content != "remote body" {
+		t.Errorf("unexpected cached content: %q", skill.Content)
+	}
+	if hits != 1 {
+		t.Errorf("expected exactly 1 network hit, got %d", hits)
+	}
+}
+
+func TestResolveURLGitHub(t *testing.T) {
+	got, err := resolveURL(RemoteSource{Source: "github.com/acme/repo/skills/refunds.md", Ref: "abc123"})
+	if err != nil {
+		t.Fatalf("resolveURL: %v", err)
+	}
+	want := "https://raw.githubusercontent.com/acme/repo/abc123/skills/refunds.md"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveURLGitHubRequiresRef(t *testing.T) {
+	if _, err := resolveURL(RemoteSource{Source: "github.com/acme/repo/skill.md"}); err == nil {
+		t.Error("expected error when ref is missing")
+	}
+}
+
+func TestResolveURLUnsupported(t *testing.T) {
+	if _, err := resolveURL(RemoteSource{Source: "ftp://example.com/x"}); err == nil {
+		t.Error("expected unsupported-source error")
+	}
+}

--- a/pkg/skills/skill.go
+++ b/pkg/skills/skill.go
@@ -1,0 +1,192 @@
+// Package skills implements Eve-style on-demand skills: units of knowledge or
+// procedure stored as markdown files. Rather than dumping every procedure into
+// the system prompt, an agent advertises a catalog of skill names and
+// descriptions, and the model pulls the full body only when it needs it via the
+// load_skill builtin tool.
+package skills
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ryanhill4L/agents-sdk/pkg/tools"
+)
+
+// Skill is a single unit of on-demand knowledge.
+type Skill struct {
+	// Name is the identifier the model uses to load the skill.
+	Name string `yaml:"name"`
+	// Description is shown in the skill catalog so the model knows when to load it.
+	Description string `yaml:"description"`
+	// Content is the body of the skill (everything after the front-matter).
+	Content string `yaml:"-"`
+	// Path is the source file, when loaded from disk.
+	Path string `yaml:"-"`
+}
+
+// frontMatter mirrors the YAML header of a skill file.
+type frontMatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+// Parse reads a skill from raw markdown bytes. The file may begin with a YAML
+// front-matter block delimited by lines containing only "---". If the
+// front-matter omits a name, defaultName is used.
+func Parse(data []byte, defaultName string) (Skill, error) {
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+
+	skill := Skill{Name: defaultName}
+
+	if strings.HasPrefix(text, "---\n") {
+		rest := text[len("---\n"):]
+		if idx := strings.Index(rest, "\n---\n"); idx >= 0 {
+			header := rest[:idx]
+			body := rest[idx+len("\n---\n"):]
+
+			var fm frontMatter
+			if err := yaml.Unmarshal([]byte(header), &fm); err != nil {
+				return Skill{}, fmt.Errorf("invalid skill front-matter: %w", err)
+			}
+			if fm.Name != "" {
+				skill.Name = fm.Name
+			}
+			skill.Description = fm.Description
+			skill.Content = strings.TrimSpace(body)
+			if skill.Name == "" {
+				return Skill{}, fmt.Errorf("skill is missing a name")
+			}
+			return skill, nil
+		}
+	}
+
+	// No front-matter: the whole file is the body, derive a description from the
+	// first non-empty line.
+	skill.Content = strings.TrimSpace(text)
+	skill.Description = firstLine(skill.Content)
+	if skill.Name == "" {
+		return Skill{}, fmt.Errorf("skill is missing a name")
+	}
+	return skill, nil
+}
+
+// LoadFile reads a single skill from a markdown file. The default name is the
+// file name without its extension.
+func LoadFile(path string) (Skill, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Skill{}, err
+	}
+	base := filepath.Base(path)
+	name := strings.TrimSuffix(base, filepath.Ext(base))
+	skill, err := Parse(data, name)
+	if err != nil {
+		return Skill{}, fmt.Errorf("%s: %w", path, err)
+	}
+	skill.Path = path
+	return skill, nil
+}
+
+// LoadDir loads every *.md file in dir as a skill. A missing directory is not an
+// error and yields no skills.
+func LoadDir(dir string) ([]Skill, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var skills []Skill
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.ToLower(filepath.Ext(entry.Name())) != ".md" {
+			continue
+		}
+		skill, err := LoadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		skills = append(skills, skill)
+	}
+	sort.Slice(skills, func(i, j int) bool { return skills[i].Name < skills[j].Name })
+	return skills, nil
+}
+
+// Catalog renders a human/model-readable list of the given skills, suitable for
+// appending to a system prompt.
+func Catalog(skills []Skill) string {
+	if len(skills) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Available skills\n")
+	b.WriteString("Use the load_skill tool to read a skill's full instructions before acting on its topic.\n\n")
+	for _, s := range skills {
+		desc := s.Description
+		if desc == "" {
+			desc = "(no description)"
+		}
+		fmt.Fprintf(&b, "- %s: %s\n", s.Name, desc)
+	}
+	return b.String()
+}
+
+// LoadSkillToolName is the name of the builtin tool that returns skill bodies.
+const LoadSkillToolName = "load_skill"
+
+// NewLoadSkillTool builds the builtin tool that lets a model fetch a skill's
+// body on demand. It closes over the provided skills.
+func NewLoadSkillTool(skills []Skill) tools.Tool {
+	index := make(map[string]Skill, len(skills))
+	names := make([]string, 0, len(skills))
+	for _, s := range skills {
+		index[s.Name] = s
+		names = append(names, s.Name)
+	}
+	sort.Strings(names)
+
+	description := fmt.Sprintf(
+		"Load the full instructions for an available skill. Valid skill names: %s.",
+		strings.Join(names, ", "),
+	)
+
+	handler := func(_ context.Context, args map[string]interface{}) (interface{}, error) {
+		name, _ := args["name"].(string)
+		if name == "" {
+			return nil, fmt.Errorf("the 'name' argument is required")
+		}
+		skill, ok := index[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown skill %q; valid skills: %s", name, strings.Join(names, ", "))
+		}
+		if skill.Content == "" {
+			return fmt.Sprintf("Skill %q has no content.", name), nil
+		}
+		return skill.Content, nil
+	}
+
+	return tools.NewTool(LoadSkillToolName, description, handler, tools.Param{
+		Name:        "name",
+		Type:        "string",
+		Description: "The name of the skill to load.",
+		Required:    true,
+	})
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(strings.TrimLeft(s, "# "))
+}

--- a/pkg/skills/skill_test.go
+++ b/pkg/skills/skill_test.go
@@ -1,0 +1,114 @@
+package skills
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseWithFrontMatter(t *testing.T) {
+	data := []byte("---\nname: refunds\ndescription: How to process a refund\n---\nStep 1. Verify the order.\nStep 2. Issue the refund.")
+	s, err := Parse(data, "fallback")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Name != "refunds" {
+		t.Errorf("name = %q, want refunds", s.Name)
+	}
+	if s.Description != "How to process a refund" {
+		t.Errorf("description = %q", s.Description)
+	}
+	if s.Content == "" || s.Content[:6] != "Step 1" {
+		t.Errorf("content = %q", s.Content)
+	}
+}
+
+func TestParseWithoutFrontMatter(t *testing.T) {
+	s, err := Parse([]byte("# Title line\nbody"), "myskill")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Name != "myskill" {
+		t.Errorf("name = %q, want myskill", s.Name)
+	}
+	if s.Description != "Title line" {
+		t.Errorf("description = %q, want 'Title line'", s.Description)
+	}
+}
+
+func TestLoadDir(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, "a.md"), "---\nname: alpha\ndescription: A\n---\nbody a")
+	write(t, filepath.Join(dir, "b.md"), "---\nname: beta\ndescription: B\n---\nbody b")
+	write(t, filepath.Join(dir, "ignore.txt"), "not a skill")
+
+	skills, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if len(skills) != 2 {
+		t.Fatalf("got %d skills, want 2", len(skills))
+	}
+	if skills[0].Name != "alpha" || skills[1].Name != "beta" {
+		t.Errorf("unexpected skill order: %q, %q", skills[0].Name, skills[1].Name)
+	}
+}
+
+func TestLoadDirMissing(t *testing.T) {
+	skills, err := LoadDir(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("LoadDir missing: %v", err)
+	}
+	if skills != nil {
+		t.Errorf("expected nil skills, got %v", skills)
+	}
+}
+
+func TestLoadSkillTool(t *testing.T) {
+	skills := []Skill{{Name: "refunds", Description: "d", Content: "the body"}}
+	tool := NewLoadSkillTool(skills)
+	if tool.Name() != LoadSkillToolName {
+		t.Fatalf("tool name = %q", tool.Name())
+	}
+
+	out, err := tool.Execute(context.Background(), map[string]interface{}{"name": "refunds"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "the body" {
+		t.Errorf("output = %v, want 'the body'", out)
+	}
+
+	if _, err := tool.Execute(context.Background(), map[string]interface{}{"name": "missing"}); err == nil {
+		t.Error("expected error for unknown skill")
+	}
+}
+
+func TestCatalog(t *testing.T) {
+	if Catalog(nil) != "" {
+		t.Error("empty catalog should be empty string")
+	}
+	c := Catalog([]Skill{{Name: "x", Description: "does x"}})
+	if c == "" || !contains(c, "x: does x") {
+		t.Errorf("catalog = %q", c)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -1,0 +1,96 @@
+package tools
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Registry is a name-indexed collection of tools.
+//
+// Because Go tools are compiled functions rather than interpreted files, the
+// filesystem-first agent definition references tools by name (in agent.yaml)
+// and resolves them against a Registry at load time. Register your tools once
+// at program startup, then point the loader at the registry.
+type Registry struct {
+	mu    sync.RWMutex
+	tools map[string]Tool
+}
+
+// NewRegistry creates an empty tool registry.
+func NewRegistry() *Registry {
+	return &Registry{tools: make(map[string]Tool)}
+}
+
+// Register adds one or more tools to the registry. It returns an error if a
+// tool with the same name was already registered or if a tool is invalid.
+func (r *Registry) Register(ts ...Tool) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, t := range ts {
+		if t == nil {
+			return fmt.Errorf("cannot register nil tool")
+		}
+		if err := t.Validate(); err != nil {
+			return fmt.Errorf("invalid tool %q: %w", t.Name(), err)
+		}
+		if _, exists := r.tools[t.Name()]; exists {
+			return fmt.Errorf("tool %q already registered", t.Name())
+		}
+		r.tools[t.Name()] = t
+	}
+	return nil
+}
+
+// MustRegister is like Register but panics on error. Useful for package-level
+// registration where a duplicate name is a programming error.
+func (r *Registry) MustRegister(ts ...Tool) {
+	if err := r.Register(ts...); err != nil {
+		panic(err)
+	}
+}
+
+// Get returns the tool registered under name.
+func (r *Registry) Get(name string) (Tool, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	t, ok := r.tools[name]
+	return t, ok
+}
+
+// Resolve looks up every requested name and returns the matching tools in the
+// same order. It returns an error listing any names that are not registered.
+func (r *Registry) Resolve(names []string) ([]Tool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	resolved := make([]Tool, 0, len(names))
+	var missing []string
+	for _, name := range names {
+		t, ok := r.tools[name]
+		if !ok {
+			missing = append(missing, name)
+			continue
+		}
+		resolved = append(resolved, t)
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("unknown tool(s): %v", missing)
+	}
+	return resolved, nil
+}
+
+// Names returns the sorted names of all registered tools.
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	names := make([]string, 0, len(r.tools))
+	for name := range r.tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -1,0 +1,60 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+func newTestTool(name string) Tool {
+	return NewTool(name, "desc", func(_ context.Context, _ map[string]interface{}) (interface{}, error) {
+		return name, nil
+	})
+}
+
+func TestRegistryRegisterAndResolve(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Register(newTestTool("a"), newTestTool("b")); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	resolved, err := r.Resolve([]string{"b", "a"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(resolved) != 2 || resolved[0].Name() != "b" || resolved[1].Name() != "a" {
+		t.Fatalf("resolve order wrong: %v", resolved)
+	}
+}
+
+func TestRegistryDuplicate(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Register(newTestTool("a"))
+	if err := r.Register(newTestTool("a")); err == nil {
+		t.Error("expected duplicate registration error")
+	}
+}
+
+func TestRegistryResolveMissing(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Register(newTestTool("a"))
+	if _, err := r.Resolve([]string{"a", "x", "y"}); err == nil {
+		t.Error("expected error for unknown tools")
+	}
+}
+
+func TestSimpleToolExecute(t *testing.T) {
+	tool := NewTool("echo", "echoes msg", func(_ context.Context, args map[string]interface{}) (interface{}, error) {
+		return args["msg"], nil
+	}, Param{Name: "msg", Type: "string", Required: true})
+
+	if got := tool.Schema().Required; len(got) != 1 || got[0] != "msg" {
+		t.Errorf("required = %v", got)
+	}
+	out, err := tool.Execute(context.Background(), map[string]interface{}{"msg": "hi"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "hi" {
+		t.Errorf("out = %v", out)
+	}
+}

--- a/pkg/tools/simple_tool.go
+++ b/pkg/tools/simple_tool.go
@@ -1,0 +1,83 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+)
+
+// HandlerFunc executes a tool given decoded arguments.
+type HandlerFunc func(ctx context.Context, args map[string]interface{}) (interface{}, error)
+
+// SimpleTool is a Tool defined by an explicit schema and a handler function.
+//
+// Unlike FunctionTool (which derives a positional schema via reflection),
+// SimpleTool lets you declare named, described parameters — which produces far
+// better tool-use behaviour from models. It is the preferred way to author
+// tools and is used internally for builtins such as load_skill.
+type SimpleTool struct {
+	name        string
+	description string
+	schema      ParameterSchema
+	handler     HandlerFunc
+}
+
+// Param describes a single named parameter for NewTool.
+type Param struct {
+	Name        string
+	Type        string // JSON schema type: string, integer, number, boolean, array, object
+	Description string
+	Required    bool
+}
+
+// NewTool builds a SimpleTool from a name, description, handler and parameters.
+func NewTool(name, description string, handler HandlerFunc, params ...Param) *SimpleTool {
+	schema := ParameterSchema{
+		Type:       "object",
+		Properties: make(map[string]PropertySchema, len(params)),
+		Required:   make([]string, 0, len(params)),
+	}
+	for _, p := range params {
+		typ := p.Type
+		if typ == "" {
+			typ = "string"
+		}
+		schema.Properties[p.Name] = PropertySchema{Type: typ, Description: p.Description}
+		if p.Required {
+			schema.Required = append(schema.Required, p.Name)
+		}
+	}
+	return &SimpleTool{
+		name:        name,
+		description: description,
+		schema:      schema,
+		handler:     handler,
+	}
+}
+
+// Name returns the tool name.
+func (t *SimpleTool) Name() string { return t.name }
+
+// Description returns the tool description.
+func (t *SimpleTool) Description() string { return t.description }
+
+// Schema returns the parameter schema.
+func (t *SimpleTool) Schema() ParameterSchema { return t.schema }
+
+// Execute runs the handler with the provided arguments.
+func (t *SimpleTool) Execute(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	if t.handler == nil {
+		return nil, fmt.Errorf("tool %q has no handler", t.name)
+	}
+	return t.handler(ctx, args)
+}
+
+// Validate checks that the tool is usable.
+func (t *SimpleTool) Validate() error {
+	if t.name == "" {
+		return fmt.Errorf("tool name cannot be empty")
+	}
+	if t.handler == nil {
+		return fmt.Errorf("tool %q has no handler", t.name)
+	}
+	return nil
+}

--- a/pkg/tracing/console.go
+++ b/pkg/tracing/console.go
@@ -1,0 +1,88 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ConsoleTracer renders spans as an indented tree to a writer (stderr by
+// default), one line per span when it ends, showing duration and attributes.
+type ConsoleTracer struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// NewConsoleTracer writes traces to stderr.
+func NewConsoleTracer() Tracer { return &ConsoleTracer{w: os.Stderr} }
+
+// NewConsoleTracerTo writes traces to w.
+func NewConsoleTracerTo(w io.Writer) Tracer { return &ConsoleTracer{w: w} }
+
+// StartSpan begins a console span at the current context depth.
+func (t *ConsoleTracer) StartSpan(ctx context.Context, name string, attrs []Attr) Span {
+	return &consoleSpan{
+		tracer: t,
+		name:   name,
+		depth:  Depth(ctx),
+		start:  time.Now(),
+		attrs:  append([]Attr(nil), attrs...),
+	}
+}
+
+func (t *ConsoleTracer) write(line string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	fmt.Fprintln(t.w, line)
+}
+
+type consoleSpan struct {
+	tracer *ConsoleTracer
+	name   string
+	depth  int
+	start  time.Time
+	attrs  []Attr
+	err    error
+	ended  bool
+}
+
+func (s *consoleSpan) SetAttributes(attrs ...Attr) { s.attrs = append(s.attrs, attrs...) }
+func (s *consoleSpan) SetError(err error)          { s.err = err }
+
+func (s *consoleSpan) End() {
+	if s.ended {
+		return
+	}
+	s.ended = true
+	dur := time.Since(s.start)
+
+	var b strings.Builder
+	b.WriteString("[trace] ")
+	b.WriteString(strings.Repeat("  ", s.depth))
+	b.WriteString(s.name)
+	fmt.Fprintf(&b, " (%s)", dur.Round(time.Microsecond))
+	for _, a := range s.attrs {
+		fmt.Fprintf(&b, " %s=%v", a.Key, formatValue(a.Value))
+	}
+	if s.err != nil {
+		fmt.Fprintf(&b, " error=%q", s.err.Error())
+	}
+	s.tracer.write(b.String())
+}
+
+// formatValue keeps trace lines readable by truncating long string values.
+func formatValue(v any) any {
+	if str, ok := v.(string); ok {
+		const max = 120
+		str = strings.ReplaceAll(str, "\n", "\\n")
+		if len(str) > max {
+			return str[:max] + "…"
+		}
+		return str
+	}
+	return v
+}

--- a/pkg/tracing/log.go
+++ b/pkg/tracing/log.go
@@ -1,0 +1,107 @@
+package tracing
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// DiscardLogger returns a *slog.Logger that drops all records. It is the safe
+// default when no logger is configured.
+func DiscardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// OrDiscard returns logger, or a DiscardLogger when logger is nil.
+func OrDiscard(logger *slog.Logger) *slog.Logger {
+	if logger == nil {
+		return DiscardLogger()
+	}
+	return logger
+}
+
+// NewLogger builds a text logger writing to w (stderr if nil) at the given
+// level.
+func NewLogger(w io.Writer, level slog.Level) *slog.Logger {
+	if w == nil {
+		w = os.Stderr
+	}
+	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: level}))
+}
+
+// ParseLevel maps a string (debug/info/warn/error) to an slog.Level, defaulting
+// to info.
+func ParseLevel(s string) slog.Level {
+	switch s {
+	case "debug", "DEBUG":
+		return slog.LevelDebug
+	case "warn", "WARN", "warning":
+		return slog.LevelWarn
+	case "error", "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// SlogTracer renders spans as slog records (one debug record per span end,
+// including duration and attributes).
+type SlogTracer struct {
+	logger *slog.Logger
+}
+
+// NewSlogTracer returns a tracer that emits spans to logger (or a discard
+// logger when nil).
+func NewSlogTracer(logger *slog.Logger) Tracer {
+	return &SlogTracer{logger: OrDiscard(logger)}
+}
+
+// StartSpan begins an slog-backed span.
+func (t *SlogTracer) StartSpan(ctx context.Context, name string, attrs []Attr) Span {
+	return &slogSpan{
+		logger: t.logger,
+		ctx:    ctx,
+		name:   name,
+		depth:  Depth(ctx),
+		start:  time.Now(),
+		attrs:  append([]Attr(nil), attrs...),
+	}
+}
+
+type slogSpan struct {
+	logger *slog.Logger
+	ctx    context.Context
+	name   string
+	depth  int
+	start  time.Time
+	attrs  []Attr
+	err    error
+	ended  bool
+}
+
+func (s *slogSpan) SetAttributes(attrs ...Attr) { s.attrs = append(s.attrs, attrs...) }
+func (s *slogSpan) SetError(err error)          { s.err = err }
+
+func (s *slogSpan) End() {
+	if s.ended {
+		return
+	}
+	s.ended = true
+
+	args := []any{
+		slog.String("span", s.name),
+		slog.Int("depth", s.depth),
+		slog.Duration("duration", time.Since(s.start)),
+	}
+	for _, a := range s.attrs {
+		args = append(args, slog.Any(a.Key, a.Value))
+	}
+	level := slog.LevelDebug
+	if s.err != nil {
+		args = append(args, slog.String("error", s.err.Error()))
+		level = slog.LevelError
+	}
+	s.logger.Log(s.ctx, level, "span", args...)
+}

--- a/pkg/tracing/recorder.go
+++ b/pkg/tracing/recorder.go
@@ -1,0 +1,84 @@
+package tracing
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+)
+
+// SpanRecord is a completed span captured by a Recorder.
+type SpanRecord struct {
+	Name       string
+	Depth      int
+	Attributes []Attr
+	Error      string
+	StartedAt  time.Time
+	Duration   time.Duration
+}
+
+// Recorder is a Tracer that captures spans in memory for programmatic access
+// (e.g. RunResult.Traces) and tests.
+type Recorder struct {
+	mu      sync.Mutex
+	records []SpanRecord
+}
+
+// NewRecorder returns an empty recorder.
+func NewRecorder() *Recorder { return &Recorder{} }
+
+// StartSpan begins a recorded span.
+func (r *Recorder) StartSpan(ctx context.Context, name string, attrs []Attr) Span {
+	return &recordingSpan{
+		rec:   r,
+		depth: Depth(ctx),
+		start: time.Now(),
+		record: SpanRecord{
+			Name:       name,
+			Depth:      Depth(ctx),
+			Attributes: append([]Attr(nil), attrs...),
+		},
+	}
+}
+
+// Records returns the captured spans, ordered by start time.
+func (r *Recorder) Records() []SpanRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := make([]SpanRecord, len(r.records))
+	copy(out, r.records)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].StartedAt.Before(out[j].StartedAt) })
+	return out
+}
+
+type recordingSpan struct {
+	rec    *Recorder
+	depth  int
+	start  time.Time
+	record SpanRecord
+	ended  bool
+}
+
+func (s *recordingSpan) SetAttributes(attrs ...Attr) {
+	s.record.Attributes = append(s.record.Attributes, attrs...)
+}
+
+func (s *recordingSpan) SetError(err error) {
+	if err != nil {
+		s.record.Error = err.Error()
+	}
+}
+
+func (s *recordingSpan) End() {
+	if s.ended {
+		return
+	}
+	s.ended = true
+	s.record.StartedAt = s.start
+	s.record.Duration = time.Since(s.start)
+
+	s.rec.mu.Lock()
+	s.rec.records = append(s.rec.records, s.record)
+	s.rec.mu.Unlock()
+}

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -1,100 +1,132 @@
+// Package tracing provides span-based tracing and structured logging for agent
+// runs. A Tracer renders spans (to the console, to slog, or into a recorder for
+// programmatic access); span depth is tracked through context.Context so traces
+// form a tree. Use Start to open an instrumented span:
+//
+//	ctx, span := tracing.Start(ctx, tracer, "tool.execute", tracing.A("name", "add"))
+//	defer span.End()
 package tracing
 
-import (
-	"context"
-	"time"
-)
+import "context"
 
-// Tracer provides distributed tracing capabilities
-type Tracer interface {
-	// StartSpan starts a new span with the given name
-	StartSpan(ctx context.Context, name string) (context.Context, Span)
-
-	// EndSpan ends the given span
-	EndSpan(span Span)
+// Attr is a key/value attribute attached to a span.
+type Attr struct {
+	Key   string
+	Value any
 }
 
-// Span represents a single trace span
+// A is shorthand for constructing an Attr.
+func A(key string, value any) Attr { return Attr{Key: key, Value: value} }
+
+// Tracer renders spans. Implementations must be safe for concurrent use.
+type Tracer interface {
+	// StartSpan begins a span. The returned Span is ended by the caller. Depth
+	// for tree rendering is read from ctx via Depth.
+	StartSpan(ctx context.Context, name string, attrs []Attr) Span
+}
+
+// Span represents an in-progress operation.
 type Span interface {
-	// SetAttribute sets an attribute on the span
-	SetAttribute(key string, value interface{})
-
-	// SetError marks the span as having an error
+	// SetAttributes adds attributes to the span.
+	SetAttributes(attrs ...Attr)
+	// SetError marks the span as failed.
 	SetError(err error)
-
-	// End ends the span
+	// End completes the span.
 	End()
 }
 
-// NewNoOpTracer creates a tracer that does nothing
-// This is referenced in runner.go
-func NewNoOpTracer() Tracer {
-	return &NoOpTracer{}
+// Start opens a span on tr and returns a child context whose depth is one
+// greater, so nested Start calls form a tree. A nil tracer is treated as NoOp.
+func Start(ctx context.Context, tr Tracer, name string, attrs ...Attr) (context.Context, Span) {
+	if tr == nil {
+		tr = NoOpTracer{}
+	}
+	span := tr.StartSpan(ctx, name, attrs)
+	return withDepth(ctx, Depth(ctx)+1), span
 }
 
-// NoOpTracer is a no-operation tracer for when tracing is disabled
+type depthKey struct{}
+
+// Depth returns the current span depth carried by ctx (0 at the root).
+func Depth(ctx context.Context) int {
+	if ctx == nil {
+		return 0
+	}
+	if d, ok := ctx.Value(depthKey{}).(int); ok {
+		return d
+	}
+	return 0
+}
+
+func withDepth(ctx context.Context, d int) context.Context {
+	return context.WithValue(ctx, depthKey{}, d)
+}
+
+// NoOpTracer discards all spans. It is the default.
 type NoOpTracer struct{}
 
-func (t *NoOpTracer) StartSpan(ctx context.Context, name string) (context.Context, Span) {
-	return ctx, &NoOpSpan{}
-}
+// NewNoOpTracer returns a tracer that does nothing.
+func NewNoOpTracer() Tracer { return NoOpTracer{} }
 
-func (t *NoOpTracer) EndSpan(span Span) {
-	// No-op
-}
+// StartSpan returns a no-op span.
+func (NoOpTracer) StartSpan(context.Context, string, []Attr) Span { return noOpSpan{} }
 
-// NoOpSpan is a no-operation span
-type NoOpSpan struct{}
+type noOpSpan struct{}
 
-func (s *NoOpSpan) SetAttribute(key string, value interface{}) {
-	// No-op
-}
+func (noOpSpan) SetAttributes(...Attr) {}
+func (noOpSpan) SetError(error)        {}
+func (noOpSpan) End()                  {}
 
-func (s *NoOpSpan) SetError(err error) {
-	// No-op
-}
+// Tee fans a span out to several tracers at once (e.g. console + recorder).
+type Tee []Tracer
 
-func (s *NoOpSpan) End() {
-	// No-op
-}
-
-// ConsoleTracer is a simple tracer that logs to stdout
-type ConsoleTracer struct{}
-
-func NewConsoleTracer() Tracer {
-	return &ConsoleTracer{}
-}
-
-func (t *ConsoleTracer) StartSpan(ctx context.Context, name string) (context.Context, Span) {
-	span := &ConsoleSpan{
-		Name:      name,
-		StartTime: time.Now(),
+// NewTee combines tracers, dropping nils. If only one remains it is returned
+// directly; if none, a NoOpTracer is returned.
+func NewTee(tracers ...Tracer) Tracer {
+	var kept Tee
+	for _, t := range tracers {
+		if t != nil {
+			if _, isNoop := t.(NoOpTracer); isNoop {
+				continue
+			}
+			kept = append(kept, t)
+		}
 	}
-	return ctx, span
-}
-
-func (t *ConsoleTracer) EndSpan(span Span) {
-	if cs, ok := span.(*ConsoleSpan); ok {
-		duration := time.Since(cs.StartTime)
-		println("TRACE:", cs.Name, "completed in", duration.String())
+	switch len(kept) {
+	case 0:
+		return NoOpTracer{}
+	case 1:
+		return kept[0]
+	default:
+		return kept
 	}
 }
 
-// ConsoleSpan logs span information to stdout
-type ConsoleSpan struct {
-	Name      string
-	StartTime time.Time
+// StartSpan starts the span on every underlying tracer.
+func (t Tee) StartSpan(ctx context.Context, name string, attrs []Attr) Span {
+	spans := make([]Span, 0, len(t))
+	for _, tr := range t {
+		spans = append(spans, tr.StartSpan(ctx, name, attrs))
+	}
+	return teeSpan(spans)
 }
 
-func (s *ConsoleSpan) SetAttribute(key string, value interface{}) {
-	println("TRACE:", s.Name, "attribute:", key, "=", value)
+type teeSpan []Span
+
+func (s teeSpan) SetAttributes(attrs ...Attr) {
+	for _, sp := range s {
+		sp.SetAttributes(attrs...)
+	}
 }
 
-func (s *ConsoleSpan) SetError(err error) {
-	println("TRACE:", s.Name, "error:", err.Error())
+func (s teeSpan) SetError(err error) {
+	for _, sp := range s {
+		sp.SetError(err)
+	}
 }
 
-func (s *ConsoleSpan) End() {
-	duration := time.Since(s.StartTime)
-	println("TRACE:", s.Name, "ended after", duration.String())
+func (s teeSpan) End() {
+	for _, sp := range s {
+		sp.End()
+	}
 }

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -25,7 +25,8 @@ type Tracer interface {
 	StartSpan(ctx context.Context, name string, attrs []Attr) Span
 }
 
-// Span represents an in-progress operation.
+// Span represents an in-progress operation. A single Span is not safe for
+// concurrent use; give each goroutine its own span (via Start).
 type Span interface {
 	// SetAttributes adds attributes to the span.
 	SetAttributes(attrs ...Attr)

--- a/pkg/tracing/tracer_test.go
+++ b/pkg/tracing/tracer_test.go
@@ -1,0 +1,84 @@
+package tracing
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRecorderCapturesDepthAndAttrs(t *testing.T) {
+	rec := NewRecorder()
+	ctx := context.Background()
+
+	ctx, root := Start(ctx, rec, "run", A("agent", "a"))
+	_, child := Start(ctx, rec, "turn", A("n", 0))
+	child.SetAttributes(A("extra", true))
+	child.End()
+	root.SetError(errors.New("boom"))
+	root.End()
+
+	records := rec.Records()
+	if len(records) != 2 {
+		t.Fatalf("got %d records, want 2", len(records))
+	}
+	// Ordered by start time: run first, then turn.
+	if records[0].Name != "run" || records[0].Depth != 0 {
+		t.Errorf("record0 = %+v", records[0])
+	}
+	if records[0].Error != "boom" {
+		t.Errorf("expected error captured, got %q", records[0].Error)
+	}
+	if records[1].Name != "turn" || records[1].Depth != 1 {
+		t.Errorf("record1 = %+v", records[1])
+	}
+}
+
+func TestTeeFansOut(t *testing.T) {
+	a, b := NewRecorder(), NewRecorder()
+	tee := NewTee(a, b, NoOpTracer{}, nil)
+
+	_, span := Start(context.Background(), tee, "x")
+	span.End()
+
+	if len(a.Records()) != 1 || len(b.Records()) != 1 {
+		t.Errorf("expected both recorders to capture the span")
+	}
+}
+
+func TestNewTeeCollapses(t *testing.T) {
+	if _, ok := NewTee(nil, NoOpTracer{}).(NoOpTracer); !ok {
+		t.Error("NewTee with no real tracers should be NoOpTracer")
+	}
+	rec := NewRecorder()
+	if NewTee(rec) != Tracer(rec) {
+		t.Error("NewTee with one tracer should return it directly")
+	}
+}
+
+func TestConsoleTracerOutput(t *testing.T) {
+	var buf bytes.Buffer
+	tr := NewConsoleTracerTo(&buf)
+
+	ctx, root := Start(context.Background(), tr, "run", A("agent", "demo"))
+	_, child := Start(ctx, tr, "tool.execute", A("tool", "add"))
+	child.End()
+	root.End()
+
+	out := buf.String()
+	if !strings.Contains(out, "run") || !strings.Contains(out, "agent=demo") {
+		t.Errorf("missing root span line: %q", out)
+	}
+	if !strings.Contains(out, "  tool.execute") || !strings.Contains(out, "tool=add") {
+		t.Errorf("missing indented child span line: %q", out)
+	}
+}
+
+func TestFormatValueTruncates(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	got, ok := formatValue(long).(string)
+	if !ok || len(got) <= 120 || !strings.HasSuffix(got, "…") {
+		t.Errorf("expected truncation, got len %d", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

A full reimagining of the SDK around a **filesystem-first** authoring model inspired by [Vercel's Eve](https://github.com/vercel/eve), adapted to Go. Per direction agreed up front: **stay in Go**, do an **Eve-inspired reimagining** (not a literal clone, no Vercel lock-in), and **salvage the existing engine** rather than starting from scratch.

An agent is now a **directory of conventional files**, loaded into the existing `agents.Agent` / `Runner`:

```
myagent/
  agent.yaml            # model, provider, temperature, tools[]
  instructions.md       # system prompt
  skills/*.md           # on-demand knowledge (front-matter + body)
  subagents/<name>/     # delegated agents → existing Handoffs
  schedules/*.yaml      # cron triggers
```

## What's new

**New packages**
- `pkg/loader` — builds an `Agent` from a directory; resolves tools declared by name against a registry; loads subagents recursively as handoffs.
- `pkg/skills` — Eve-style on-demand skills (markdown + YAML front-matter). The model sees a **catalog** in the prompt and pulls a skill's body via the `load_skill` builtin tool, rather than inlining all knowledge.
- `pkg/channels` — `Channel` interface + built-in `HTTPChannel` (powers `eve dev`, `POST /chat`).
- `pkg/schedules` — dependency-free 5-field cron parser/matcher + minute-tick scheduler.
- `cmd/eve` — CLI: `init` / `validate` / `run` / `dev` / `schedules`.

**Engine additions (salvaging existing code)**
- `tools.Registry` and `tools.SimpleTool`/`NewTool` for clean named-parameter schemas (the reflection-based `FunctionTool` is retained).
- `agents` skills wiring: `Skills` field, `WithSkills`, skill catalog appended in `GetInstructions()`, and `EffectiveTools()` exposing `load_skill`. Added `Provider`/`Dir` fields.
- `providers.Resolve(name)` to construct a provider from a name + environment (with auto-detect).

The OpenAI/Anthropic/Gemini/Ollama providers, `pkg/memory`, `pkg/guardrails`, `pkg/tracing`, and the existing code-first examples are all **preserved**.

## Design note: tools in Go

Because Go tools are compiled functions (not interpreted files like Eve's `tools/*.ts`), `agent.yaml` references tools **by name** and they're resolved against a `tools.Registry`. The CLI ships a small builtin registry (`current_time`, `add`, `http_get`); custom Go tools are wired via `loader.Load(dir, registry)` from your own program.

## Docs & examples
- README rewritten around the filesystem-first model; CLI quickstart added to QUICKSTART.
- `examples/filesystem-agent/` — full layout (agent + skill + subagent + schedule), driven by the `eve` CLI.
- `CLAUDE.md` and `Makefile` refreshed (`make build-cli`, `make run-fs-example`).

## Testing
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass; new files are `gofmt`-clean.
- New tests cover the loader, skills, cron schedules, the tool registry/SimpleTool, and the agents skills wiring.
- Smoke-tested the CLI: `eve init` → `eve validate` on a scaffold and on the example, and `eve dev`'s HTTP endpoints (`/health`, method/validation errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7TfnXCco6xzKLK2NY8NqD)_